### PR TITLE
Set up ErrorBoundaries to catch any errors thrown within the main App Component tree & refactor the Axios req configs to support cancellation via the CancelToken API

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,6 +29,7 @@
     "react": "^17.0.1",
     "react-document-title": "^2.0.3",
     "react-dom": "^17.0.1",
+    "react-error-boundary": "^4.0.11",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/packages/client/src/App.js
+++ b/packages/client/src/App.js
@@ -1,7 +1,7 @@
 import React, { useEffect, Suspense, lazy } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { Switch, Route } from 'react-router-dom'
-import { Spin, BackTop, notification as antdNotifications } from 'antd'
+import { Switch, Route, Link } from 'react-router-dom'
+import { Spin, BackTop, Result, notification as antdNotifications } from 'antd'
 
 import AuthLayout from '@layouts/AuthLayout/index'
 import MainLayout from '@layouts/MainLayout/index'
@@ -124,8 +124,23 @@ const App = () => {
               </MainLayout>
             )}
           />
-          {/* // TODO: add 403, 404 and 500 pages */}
-          <Route path='*' render={() => <div>Error, 404 Page!</div>} />
+          <Route
+            path='*'
+            render={() => (
+              <Result
+                style={{ margin: 'auto' }}
+                status={404}
+                title={
+                  <>
+                    <strong>404</strong>
+                    <p>Page Not Found</p>
+                  </>
+                }
+                subTitle="The page you are looking for doesn't exists."
+                extra={<Link to='/'>Back to Home</Link>}
+              />
+            )}
+          />
         </Switch>
         <BackTop />
       </Suspense>

--- a/packages/client/src/App.js
+++ b/packages/client/src/App.js
@@ -1,5 +1,6 @@
 import React, { useEffect, Suspense, lazy } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Switch, Route, Link } from 'react-router-dom'
 import { Spin, BackTop, Result, notification as antdNotifications } from 'antd'
 
@@ -14,6 +15,7 @@ import ProtectedRoute from '@components/ProtectedRoute/index'
 import { authUser } from '@redux/user/userThunk'
 import { selectLoggedInUser } from '@redux/user/userSlice'
 import { selectNotifications } from '@redux/notification/notificationSlice'
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 
 import './App.less'
 
@@ -31,18 +33,28 @@ const App = () => {
   const dispatch = useDispatch()
   const loggedInUser = useSelector(selectLoggedInUser)
   const notifications = useSelector(selectNotifications)
+  const { showBoundary } = useErrorBoundary()
 
   useEffect(() => {
+    let response
+
     const getAuthUser = async () => {
       try {
-        await dispatch(authUser())
+        response = dispatch(authUser())
+        await response?.unwrap?.()
       } catch (err) {
-        console.log(err)
+        handleAsyncThunkError(err, showBoundary, {
+          showBoundaryOnlyOnServerError: true,
+        })
       }
     }
 
     getAuthUser()
-  }, [dispatch])
+
+    return () => {
+      response?.abort?.('Request Aborted due to component unmount.')
+    }
+  }, [dispatch, showBoundary])
 
   useEffect(() => {
     if (!loggedInUser.info && loggedInUser.auth === 'unauthenticated') {

--- a/packages/client/src/api/collection/index.js
+++ b/packages/client/src/api/collection/index.js
@@ -5,15 +5,13 @@ const axios = Axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
-const getCollections = async () => {
-  const response = await axios()
-
+const getCollections = async cancelToken => {
+  const response = await axios({ cancelToken })
   return response
 }
 
-const getCollectionsByGender = async gender => {
-  const response = await axios(`/${gender}`)
-
+const getCollectionsByGender = async (gender, cancelToken) => {
+  const response = await axios(`/${gender}`, { cancelToken })
   return response
 }
 

--- a/packages/client/src/api/offer/index.js
+++ b/packages/client/src/api/offer/index.js
@@ -5,9 +5,8 @@ const axios = Axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
-const getOffers = async () => {
-  const response = await axios()
-
+const getOffers = async cancelToken => {
+  const response = await axios({ cancelToken })
   return response
 }
 

--- a/packages/client/src/api/order/index.js
+++ b/packages/client/src/api/order/index.js
@@ -5,33 +5,38 @@ const axios = Axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
-const getOrders = async urlQueryParams => {
-  const response = await axios({ params: urlQueryParams })
+const getOrders = async (params, cancelToken) => {
+  const response = await axios({ params, cancelToken })
   return response
 }
 
-export const getTotalOrdersCount = async () => {
-  const response = await axios('/count')
+export const getTotalOrdersCount = async cancelToken => {
+  const response = await axios('/count', { cancelToken })
   return response
 }
 
-export const getTotalOrdersSales = async urlQueryParams => {
-  const response = await axios('/total-sales', { params: urlQueryParams })
+export const getTotalOrdersSales = async (cancelToken, params) => {
+  const response = await axios('/total-sales', {
+    params,
+    cancelToken,
+  })
   return response
 }
 
-const getOrderById = async oid => {
-  const response = await axios(`/${oid}`)
+const getOrderById = async (oid, cancelToken) => {
+  const response = await axios(`/${oid}`, { cancelToken })
   return response
 }
 
-export const getOrdersByUserId = async uid => {
-  const response = await axios(`/users/${uid}`)
+export const getOrdersByUserId = async (uid, cancelToken) => {
+  const response = await axios(`/users/${uid}`, {
+    cancelToken,
+  })
   return response
 }
 
-export const createNewOrder = async data => {
-  const response = await axios.post('/create', data)
+export const createNewOrder = async (data, cancelToken) => {
+  const response = await axios.post('/create', data, { cancelToken })
   return response
 }
 

--- a/packages/client/src/api/product/index.js
+++ b/packages/client/src/api/product/index.js
@@ -5,55 +5,51 @@ const axios = Axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
-const getProducts = async urlQueryParams => {
-  const response = await axios({ params: urlQueryParams })
-
+const getProducts = async (params, cancelToken) => {
+  const response = await axios({ params, cancelToken })
   return response
 }
 
-export const getTotalProductsCount = async () => {
-  const response = await axios('/count')
+export const getTotalProductsCount = async cancelToken => {
+  const response = await axios('/count', { cancelToken })
   return response
 }
 
-const getProductById = async pid => {
-  const response = await axios(`/${pid}`)
-
+const getProductById = async (pid, cancelToken) => {
+  const response = await axios(`/${pid}`, { cancelToken })
   return response
 }
 
-const getLatestProducts = async () => {
-  const response = await axios('/latest')
-
+const getLatestProducts = async cancelToken => {
+  const response = await axios('/latest', { cancelToken })
   return response
 }
 
-const getTopRatedProducts = async () => {
-  const response = await axios('/top-rated')
-
+const getTopRatedProducts = async cancelToken => {
+  const response = await axios('/top-rated', { cancelToken })
   return response
 }
 
-const getProductReviews = async pid => {
-  const response = await axios(`/products/${pid}`, { baseURL: '/api/reviews' })
+const getProductReviews = async (pid, cancelToken) => {
+  const response = await axios(`/products/${pid}`, {
+    baseURL: '/api/reviews',
+    cancelToken,
+  })
   return response
 }
 
-export const createNewProduct = async data => {
-  const response = await axios.post('/create', data)
-
+export const createNewProduct = async (data, cancelToken) => {
+  const response = await axios.post('/create', data, { cancelToken })
   return response
 }
 
-const updateProduct = async (pid, data) => {
-  const response = await axios.put(`/${pid}`, data)
-
+const updateProduct = async (pid, data, cancelToken) => {
+  const response = await axios.put(`/${pid}`, data, { cancelToken })
   return response
 }
 
-export const deleteProduct = async pid => {
-  const response = await axios.delete(`/${pid}`)
-
+export const deleteProduct = async (pid, cancelToken) => {
+  const response = await axios.delete(`/${pid}`, { cancelToken })
   return response
 }
 

--- a/packages/client/src/api/user/auth.js
+++ b/packages/client/src/api/user/auth.js
@@ -5,39 +5,35 @@ const axios = Axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
-const authUser = async () => {
-  const response = await axios()
-
+const authUser = async cancelToken => {
+  const response = await axios({ cancelToken })
   return response
 }
 
-const signin = async data => {
-  const response = await axios.post('/signin', data)
-
+const signin = async (data, cancelToken) => {
+  const response = await axios.post('/signin', data, { cancelToken })
   return response
 }
 
-export const signup = async (data, path = '/signup') => {
-  const response = await axios.post(path, data)
-
+export const signup = async (data, cancelToken, path = '/signup') => {
+  const response = await axios.post(path, data, { cancelToken })
   return response
 }
 
-const signout = async () => {
-  const response = await axios('/signout')
-
+const signout = async cancelToken => {
+  const response = await axios('/signout', { cancelToken })
   return response
 }
 
-export const forgotPassword = async data => {
-  const response = await axios.post('/forgot-password', data)
-
+export const forgotPassword = async (data, cancelToken) => {
+  const response = await axios.post('/forgot-password', data, { cancelToken })
   return response
 }
 
-export const resetPassword = async (data, resetToken) => {
-  const response = await axios.put(`/reset-password/${resetToken}`, data)
-
+export const resetPassword = async (data, resetToken, cancelToken) => {
+  const response = await axios.put(`/reset-password/${resetToken}`, data, {
+    cancelToken,
+  })
   return response
 }
 

--- a/packages/client/src/api/user/index.js
+++ b/packages/client/src/api/user/index.js
@@ -5,18 +5,18 @@ const axios = Axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
-const getUsers = async urlQueryParams => {
-  const response = await axios({ params: urlQueryParams })
+const getUsers = async (params, cancelToken) => {
+  const response = await axios({ params, cancelToken })
   return response
 }
 
-export const getTotalUsersCount = async () => {
-  const response = await axios('/count')
+export const getTotalUsersCount = async cancelToken => {
+  const response = await axios('/count', { cancelToken })
   return response
 }
 
-const getUserById = async uid => {
-  const response = await axios(`/${uid}`)
+const getUserById = async (uid, cancelToken) => {
+  const response = await axios(`/${uid}`, { cancelToken })
   return response
 }
 
@@ -25,30 +25,37 @@ const getPurchasedProductsAndReviews = async (uid, cancelToken) => {
   return response
 }
 
-const updateUser = async (uid, data) => {
-  const response = await axios.put(`/${uid}`, data)
+const updateUser = async (uid, data, cancelToken) => {
+  const response = await axios.put(`/${uid}`, data, { cancelToken })
   return response
 }
 
-export const deleteUser = async uid => {
-  const response = await axios.delete(`/${uid}`)
+export const deleteUser = async (uid, cancelToken) => {
+  const response = await axios.delete(`/${uid}`, { cancelToken })
   return response
 }
 
-const createReview = async (pid, data) => {
+const createReview = async (pid, data, cancelToken) => {
   const response = await axios.post(`/products/${pid}`, data, {
     baseURL: '/api/reviews',
+    cancelToken,
   })
   return response
 }
 
-const updateReview = async (rid, data) => {
-  const response = await axios.put(`/${rid}`, data, { baseURL: '/api/reviews' })
+const updateReview = async (rid, data, cancelToken) => {
+  const response = await axios.put(`/${rid}`, data, {
+    baseURL: '/api/reviews',
+    cancelToken,
+  })
   return response
 }
 
-const deleteReview = async rid => {
-  const response = await axios.delete(`/${rid}`, { baseURL: '/api/reviews' })
+const deleteReview = async (rid, cancelToken) => {
+  const response = await axios.delete(`/${rid}`, {
+    baseURL: '/api/reviews',
+    cancelToken,
+  })
   return response
 }
 

--- a/packages/client/src/components/AdminSiderMenu/index.jsx
+++ b/packages/client/src/components/AdminSiderMenu/index.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useSelector, useDispatch } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Menu, Image } from 'antd'
 import {
   DashboardOutlined,
@@ -16,7 +17,12 @@ import { ReactComponent as UsersIcon } from '@assets/Users.svg'
 
 import { signout } from '@redux/user/userThunk'
 import { selectLoggedInUser } from '@redux/user/userSlice'
-import { removeAll as removeAllNotifications } from '@redux/notification/notificationSlice'
+import {
+  create as createNotification,
+  removeAll as removeAllNotifications,
+} from '@redux/notification/notificationSlice'
+
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 
 import './styles.scss'
 
@@ -30,6 +36,14 @@ const AdminSiderMenu = ({ collapsed }) => {
   const loggedInUser = useSelector(selectLoggedInUser)
   const [openKeys, setOpenKeys] = useState([pathname.split('/', 3).join('/')])
   const [selectedKeys, setSelectedKeys] = useState(['/admin/dashboard'])
+  const { showBoundary } = useErrorBoundary()
+  const signoutRef = useRef()
+
+  useEffect(() => {
+    return () => {
+      signoutRef.current?.abort?.('Request Aborted due to component unmount.')
+    }
+  }, [])
 
   useEffect(() => {
     switch (true) {
@@ -66,7 +80,7 @@ const AdminSiderMenu = ({ collapsed }) => {
     }
   }, [pathname, collapsed])
 
-  const handleMenuClick = e => {
+  const handleMenuClick = async e => {
     if (e.keyPath.length > 1) {
       setOpenKeys([e.keyPath[e.keyPath.length - 1]])
     } else {
@@ -78,9 +92,40 @@ const AdminSiderMenu = ({ collapsed }) => {
       return
     }
 
-    history.push('/')
-    dispatch(signout())
-    dispatch(removeAllNotifications())
+    try {
+      signoutRef.current = dispatch(signout())
+      const { message } = await signoutRef.current?.unwrap?.()
+      dispatch(
+        createNotification({
+          id: 'signoutSuccess',
+          type: 'success',
+          title: 'Success!',
+          description: message,
+        })
+      )
+
+      history.push('/')
+      dispatch(removeAllNotifications())
+    } catch (error) {
+      handleAsyncThunkError(error, showBoundary, {
+        showBoundaryOnlyOnServerError: true,
+      })
+
+      if (error.name !== 'AbortError') {
+        const { statusText, data: { message } = { message: undefined } } = error
+
+        dispatch(
+          createNotification({
+            id: 'signoutError',
+            type: 'error',
+            title: `Error, ${statusText}`,
+            description:
+              message ||
+              'Something went wrong while signing out, please try again later.',
+          })
+        )
+      }
+    }
   }
 
   const handleSubMenuOpen = keys => {

--- a/packages/client/src/components/AreaChartTooltip/index.jsx
+++ b/packages/client/src/components/AreaChartTooltip/index.jsx
@@ -27,11 +27,12 @@ const AreaChartTooltip = ({ active, payload, label }) => {
 
 AreaChartTooltip.defaultProps = {
   label: '',
+  payload: undefined,
 }
 
 AreaChartTooltip.propTypes = {
   active: PropTypes.bool.isRequired,
-  payload: PropTypes.arrayOf(Object).isRequired,
+  payload: PropTypes.arrayOf(Object),
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 

--- a/packages/client/src/components/AvatarDropdownMenu/index.jsx
+++ b/packages/client/src/components/AvatarDropdownMenu/index.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Dropdown, Menu, Avatar, Image } from 'antd'
 import {
   UserOutlined,
@@ -10,7 +11,12 @@ import {
 } from '@ant-design/icons'
 
 import { signout } from '@redux/user/userThunk'
-import { removeAll as removeAllNotifications } from '@redux/notification/notificationSlice'
+import {
+  create as createNotification,
+  removeAll as removeAllNotifications,
+} from '@redux/notification/notificationSlice'
+
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 
 import './styles.scss'
 
@@ -24,6 +30,14 @@ const AvatarDropdownMenu = ({
   const { pathname } = useLocation()
   const [isVisible, setIsVisible] = useState(false)
   const [selectedKey, setSelectedKey] = useState('')
+  const { showBoundary } = useErrorBoundary()
+  const signoutRef = useRef()
+
+  useEffect(() => {
+    return () => {
+      signoutRef.current?.abort?.('Request Aborted due to component unmount.')
+    }
+  }, [])
 
   useEffect(() => {
     if (pathname.charAt(pathname.length - 1) === '/') {
@@ -33,7 +47,7 @@ const AvatarDropdownMenu = ({
     return setSelectedKey(pathname)
   }, [pathname])
 
-  const handleMenuClick = e => {
+  const handleMenuClick = async e => {
     setIsVisible(false)
 
     if (e.key !== 'signout') {
@@ -41,8 +55,39 @@ const AvatarDropdownMenu = ({
       return
     }
 
+    try {
+      signoutRef.current = dispatch(signout())
+      const { message } = await signoutRef.current?.unwrap?.()
+      dispatch(
+        createNotification({
+          id: 'signoutSuccess',
+          type: 'success',
+          title: 'Success!',
+          description: message,
+        })
+      )
+    } catch (error) {
+      handleAsyncThunkError(error, showBoundary, {
+        showBoundaryOnlyOnServerError: true,
+      })
+
+      if (error.name !== 'AbortError') {
+        const { statusText, data: { message } = { message: undefined } } = error
+
+        dispatch(
+          createNotification({
+            id: 'signoutError',
+            type: 'error',
+            title: `Error, ${statusText}`,
+            description:
+              message ||
+              'Something went wrong while signing out, please try again later.',
+          })
+        )
+      }
+    }
+
     history.push('/')
-    dispatch(signout())
     dispatch(removeAllNotifications())
   }
 

--- a/packages/client/src/components/CollectionsFilterGroup/index.jsx
+++ b/packages/client/src/components/CollectionsFilterGroup/index.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useLocation } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Checkbox, Spin } from 'antd'
 
 import {
@@ -11,6 +12,8 @@ import {
   selectCurrentlySelectedCollectionsByGender,
 } from '@redux/collection/collectionSlice'
 import { getCollectionsByGender } from '@redux/collection/collectionThunk'
+
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 
 const CollectionsFilterGroup = ({
   name,
@@ -25,16 +28,31 @@ const CollectionsFilterGroup = ({
     selectCurrentlySelectedCollectionsByGender(gender)
   )
   const [generatedOptions, setGeneratedOptions] = useState([])
+  const { showBoundary } = useErrorBoundary()
 
   useEffect(() => {
-    if (!collections.data) {
-      dispatch(
-        getCollectionsByGender({
-          gender,
-          urlQueryParams: params.collectionName,
-        })
-      )
+    let response
+
+    const fetchCollectionsByGender = async () => {
+      if (!collections.data) {
+        try {
+          response = dispatch(
+            getCollectionsByGender({
+              gender,
+              urlQueryParams: params.collectionName,
+            })
+          )
+
+          await response?.unwrap?.()
+        } catch (error) {
+          handleAsyncThunkError(error, showBoundary, {
+            showBoundaryOnlyOnServerError: true,
+          })
+        }
+      }
     }
+
+    fetchCollectionsByGender()
 
     return () => {
       if (
@@ -43,6 +61,8 @@ const CollectionsFilterGroup = ({
       ) {
         dispatch(resetSelectedCollections({ gender }))
       }
+
+      response?.abort?.('Request Aborted due to component unmount.')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, gender])

--- a/packages/client/src/components/ErrorFallback/index.jsx
+++ b/packages/client/src/components/ErrorFallback/index.jsx
@@ -1,0 +1,63 @@
+import React, { useRef } from 'react'
+import PropTypes from 'prop-types'
+import { Link, useLocation } from 'react-router-dom'
+
+import { Result } from 'antd'
+
+const ErrorFallback = ({ error, resetErrorBoundary }) => {
+  const { pathname } = useLocation()
+  const currPath = useRef(pathname)
+
+  if (pathname !== currPath.current) {
+    resetErrorBoundary()
+    currPath.current = pathname
+  }
+
+  return (
+    <Result
+      style={{ margin: 'auto' }}
+      status={[403, 404, 500].find(
+        statusCode => statusCode === error.status || error.status < statusCode
+      )}
+      title={
+        <>
+          <strong>{error.status}</strong>
+          <p>{error.statusText}</p>
+        </>
+      }
+      subTitle={error.message || 'Something went wrong, please try again later'}
+      extra={
+        <Link to={error.redirect.to} onClick={() => resetErrorBoundary()}>
+          {error.redirect.text}
+        </Link>
+      }
+    />
+  )
+}
+
+ErrorFallback.defaultProps = {
+  error: {
+    status: 500,
+    statusText: 'Internal Server Error',
+    message: 'Something went wrong, please try again later.',
+    redirect: {
+      to: '/',
+      text: 'Back to Home',
+    },
+  },
+}
+
+ErrorFallback.propTypes = {
+  error: PropTypes.shape({
+    status: PropTypes.number,
+    statusText: PropTypes.string,
+    message: PropTypes.string,
+    redirect: PropTypes.shape({
+      to: PropTypes.string,
+      text: PropTypes.string,
+    }),
+  }),
+  resetErrorBoundary: PropTypes.func.isRequired,
+}
+
+export default ErrorFallback

--- a/packages/client/src/components/InputField/index.jsx
+++ b/packages/client/src/components/InputField/index.jsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { getIn } from 'formik'
-import { FormItem, Input } from 'formik-antd'
-import { InputNumber } from 'antd'
+import { FormItem, Input, InputNumber } from 'formik-antd'
 import { EyeTwoTone, EyeInvisibleTwoTone } from '@ant-design/icons'
 
 const InputField = ({ form, field, type, label, required, ...props }) => {

--- a/packages/client/src/components/ReviewItem/index.jsx
+++ b/packages/client/src/components/ReviewItem/index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React, { useEffect, useState, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
@@ -20,6 +19,7 @@ import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 import updateReviewValidationSchema from '@validation/review-validation'
 
 import InputField from '@components/InputField/index'
+import RouterPrompt from '@components/RouterPrompt/index'
 import DeleteConfirmPrompt from '@components/DeleteConfirmPrompt/index'
 
 const ReviewItem = ({ review, updateFor }) => {
@@ -173,26 +173,94 @@ const ReviewItem = ({ review, updateFor }) => {
         setFieldValue,
         values: { title, score, description, createdAt },
       }) => (
-        <Comment
-          key={review.id}
-          datetime={createdAt}
-          author={<h2>{title || 'Review Title'}</h2>}
-          content={
-            !reviewEditing ? (
-              <>
-                <Rate disabled allowHalf defaultValue={score} />
-                <br />
-                {description}
-                <div style={{ marginTop: '1rem' }}>
-                  <Button
-                    type='primary'
+        <>
+          <RouterPrompt when={dirty} />
+          <Comment
+            key={review.id}
+            datetime={createdAt}
+            author={<h2>{title || 'Review Title'}</h2>}
+            content={
+              !reviewEditing ? (
+                <>
+                  <Rate disabled allowHalf defaultValue={score} />
+                  <br />
+                  {description}
+                  <div style={{ marginTop: '1rem' }}>
+                    <Button
+                      type='primary'
+                      size='large'
+                      style={{ marginRight: '1rem' }}
+                      icon={<EditOutlined />}
+                      onClick={() => {
+                        setReviewEditing(true)
+                      }}>
+                      Edit
+                    </Button>
+                    <Button
+                      danger
+                      size='large'
+                      icon={<DeleteOutlined />}
+                      onClick={() => handleReviewDelete()}>
+                      Delete
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <Form
+                  key={`form-${review.id}`}
+                  layout='horizontal'
+                  size='large'>
+                  <Field
+                    required
+                    name='title'
+                    label='Title'
+                    component={InputField}
+                  />
+                  <FormItem required name='score' label='Score'>
+                    <Rate
+                      allowHalf
+                      allowClear
+                      value={score}
+                      defaultValue={score}
+                      onChange={value => setFieldValue('score', value)}
+                    />
+                  </FormItem>
+                  <Field
+                    required
+                    name='description'
+                    label='Description'
+                    type='textArea'
+                    showCount
+                    rows={5}
+                    maxLength={600}
+                    component={InputField}
+                  />
+                  <SubmitButton
                     size='large'
                     style={{ marginRight: '1rem' }}
-                    icon={<EditOutlined />}
+                    icon={<SaveOutlined />}
+                    disabled={!dirty || !isValid}>
+                    Save
+                  </SubmitButton>
+                  <ResetButton
+                    size='large'
+                    style={{
+                      marginRight: '1rem',
+                    }}
+                    icon={<UndoOutlined />}>
+                    Reset
+                  </ResetButton>
+                  <Button
+                    type='dashed'
+                    size='large'
+                    style={{
+                      marginRight: '1rem',
+                    }}
                     onClick={() => {
-                      setReviewEditing(true)
+                      handleReset()
+                      setReviewEditing(false)
                     }}>
-                    Edit
+                    Cancel
                   </Button>
                   <Button
                     danger
@@ -201,73 +269,11 @@ const ReviewItem = ({ review, updateFor }) => {
                     onClick={() => handleReviewDelete()}>
                     Delete
                   </Button>
-                </div>
-              </>
-            ) : (
-              <Form key={`form-${review.id}`} layout='horizontal' size='large'>
-                <Field
-                  required
-                  name='title'
-                  label='Title'
-                  component={InputField}
-                />
-                <FormItem required name='score' label='Score'>
-                  <Rate
-                    allowHalf
-                    allowClear
-                    value={score}
-                    defaultValue={score}
-                    onChange={value => setFieldValue('score', value)}
-                  />
-                </FormItem>
-                <Field
-                  required
-                  name='description'
-                  label='Description'
-                  type='textArea'
-                  showCount
-                  rows={5}
-                  maxLength={600}
-                  component={InputField}
-                />
-                <SubmitButton
-                  size='large'
-                  style={{ marginRight: '1rem' }}
-                  icon={<SaveOutlined />}
-                  disabled={!dirty || !isValid}>
-                  Save
-                </SubmitButton>
-                <ResetButton
-                  size='large'
-                  style={{
-                    marginRight: '1rem',
-                  }}
-                  icon={<UndoOutlined />}>
-                  Reset
-                </ResetButton>
-                <Button
-                  type='dashed'
-                  size='large'
-                  style={{
-                    marginRight: '1rem',
-                  }}
-                  onClick={() => {
-                    handleReset()
-                    setReviewEditing(false)
-                  }}>
-                  Cancel
-                </Button>
-                <Button
-                  danger
-                  size='large'
-                  icon={<DeleteOutlined />}
-                  onClick={() => handleReviewDelete()}>
-                  Delete
-                </Button>
-              </Form>
-            )
-          }
-        />
+                </Form>
+              )
+            }
+          />
+        </>
       )}
     </Formik>
   )

--- a/packages/client/src/components/ReviewItem/index.jsx
+++ b/packages/client/src/components/ReviewItem/index.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable no-unused-vars */
-import React, { useState, useCallback } from 'react'
+import React, { useEffect, useState, useRef, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Formik, Field } from 'formik'
 import { Form, FormItem, SubmitButton, ResetButton } from 'formik-antd'
 import { Comment, Rate, Button } from 'antd'
@@ -15,19 +16,34 @@ import {
 import { updateReview, deleteReview } from '@redux/user/userThunk'
 import { create as createNotification } from '@redux/notification/notificationSlice'
 
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 import updateReviewValidationSchema from '@validation/review-validation'
 
 import InputField from '@components/InputField/index'
 import DeleteConfirmPrompt from '@components/DeleteConfirmPrompt/index'
 
-const ReviewItem = ({ productId, review, updateFor }) => {
+const ReviewItem = ({ review, updateFor }) => {
   const dispatch = useDispatch()
   const [reviewEditing, setReviewEditing] = useState(false)
+  const updateReviewRef = useRef()
+  const deleteReviewRef = useRef()
+  const { showBoundary } = useErrorBoundary()
+
+  useEffect(() => {
+    return () => {
+      updateReviewRef.current?.abort?.(
+        'Request Aborted due to component unmount.'
+      )
+      deleteReviewRef.current?.abort?.(
+        'Request Aborted due to component unmount.'
+      )
+    }
+  }, [])
 
   const handleSubmit = useCallback(
     async ({ title, score, description }, { setFieldError }) => {
       try {
-        const { message } = await dispatch(
+        updateReviewRef.current = dispatch(
           updateReview({
             rid: review.id,
             updatedData: {
@@ -37,7 +53,9 @@ const ReviewItem = ({ productId, review, updateFor }) => {
             },
             updateFor,
           })
-        ).unwrap()
+        )
+
+        const { message } = await updateReviewRef.current?.unwrap?.()
 
         dispatch(
           createNotification({
@@ -49,31 +67,39 @@ const ReviewItem = ({ productId, review, updateFor }) => {
         )
         setReviewEditing(false)
       } catch (error) {
-        const {
-          status,
-          statusText,
-          data: { errors, message },
-        } = error
+        handleAsyncThunkError(error, showBoundary, {
+          showBoundaryOnlyOnServerError: true,
+        })
 
-        dispatch(
-          createNotification({
-            id: 'updateReviewError',
-            type: 'error',
-            title: `Error, ${statusText}`,
-            description:
-              message ||
-              'Something went wrong while updating a review, please try again later.',
-          })
-        )
+        if (error.name !== 'AbortError') {
+          const {
+            statusText,
+            data: { errors, message } = {
+              errors: undefined,
+              message: undefined,
+            },
+          } = error
 
-        if (errors) {
-          Object.keys(errors).forEach(err => {
-            setFieldError(err, errors[err].message)
-          })
+          dispatch(
+            createNotification({
+              id: 'updateReviewError',
+              type: 'error',
+              title: `Error, ${statusText}`,
+              description:
+                message ||
+                'Something went wrong while updating a review, please try again later.',
+            })
+          )
+
+          if (errors) {
+            Object.keys(errors).forEach(err => {
+              setFieldError(err, errors[err].message)
+            })
+          }
         }
       }
     },
-    [dispatch, review.id, updateFor]
+    [dispatch, review.id, updateFor, showBoundary]
   )
 
   const handleReviewDelete = useCallback(() => {
@@ -81,9 +107,11 @@ const ReviewItem = ({ productId, review, updateFor }) => {
       title: 'Are you sure that you want to delete this review?',
       onOk: async () => {
         try {
-          const { message } = await dispatch(
+          deleteReviewRef.current = dispatch(
             deleteReview({ rid: review.id, updateFor })
-          ).unwrap()
+          )
+
+          const { message } = await deleteReviewRef.current?.unwrap?.()
 
           dispatch(
             createNotification({
@@ -94,17 +122,27 @@ const ReviewItem = ({ productId, review, updateFor }) => {
             })
           )
         } catch (error) {
-          const { status, statusText, message } = error
-          dispatch(
-            createNotification({
-              id: 'deleteReviewError',
-              type: 'error',
-              title: statusText || 'Error!',
-              description:
-                message ||
-                'Something went wrong while deleteing a review, please try again later.',
-            })
-          )
+          handleAsyncThunkError(error, showBoundary, {
+            showBoundaryOnlyOnServerError: true,
+          })
+
+          if (error.name !== 'AbortError') {
+            const {
+              statusText,
+              data: { message } = { message: undefined },
+            } = error
+
+            dispatch(
+              createNotification({
+                id: 'deleteReviewError',
+                type: 'error',
+                title: statusText || 'Error!',
+                description:
+                  message ||
+                  'Something went wrong while deleteing a review, please try again later.',
+              })
+            )
+          }
         }
       },
     })
@@ -237,7 +275,6 @@ const ReviewItem = ({ productId, review, updateFor }) => {
 
 ReviewItem.propTypes = {
   updateFor: PropTypes.string.isRequired,
-  productId: PropTypes.string.isRequired,
   review: PropTypes.instanceOf(Object).isRequired,
 }
 

--- a/packages/client/src/components/RouterPrompt/index.jsx
+++ b/packages/client/src/components/RouterPrompt/index.jsx
@@ -1,54 +1,88 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, {
+  useLayoutEffect,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+} from 'react'
 import PropTypes from 'prop-types'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useRouteMatch, matchPath } from 'react-router-dom'
 
 import { Modal } from 'antd'
 
-const RouterPrompt = ({ when, onOk, onCancel, title, okText, cancelText }) => {
+const handleBeforeUnload = e => {
+  e.preventDefault()
+  e.returnValue = true
+}
+
+const RouterPrompt = ({ when, title, okText, cancelText }) => {
   const history = useHistory()
-
+  const { path, url } = useRouteMatch()
+  const baseUrlRef = useRef(url)
+  const unblockHistoryRef = useRef()
+  const [nextPath, setNextPath] = useState()
   const [showPrompt, setShowPrompt] = useState(false)
-  const [currentPath, setCurrentPath] = useState('')
 
-  useEffect(() => {
-    if (when) {
-      history.block(prompt => {
-        setCurrentPath(prompt.pathname)
-        setShowPrompt(true)
-        return 'true'
-      })
-    } else {
-      history.block(() => {})
+  useLayoutEffect(() => {
+    const currPath = matchPath(baseUrlRef.current, { path, exact: true })
+
+    if (currPath?.params?.activeTab) {
+      baseUrlRef.current = currPath.url.replace(
+        `/${currPath.params.activeTab}`,
+        ''
+      )
     }
 
     return () => {
-      history.block(() => {})
+      unblockHistoryRef.current?.()
+      window.removeEventListener('beforeunload', handleBeforeUnload)
     }
-  }, [history, when])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-  const handleOK = useCallback(async () => {
-    if (onOk) {
-      const canRoute = await Promise.resolve(onOk())
+  useEffect(() => {
+    if (when) {
+      /* Prevent loss of unsaved data by showing the browser-generated confirmation dialog
+       when the user tries to refresh the page or close the current tab/navigate elsewhere */
+      window.addEventListener('beforeunload', handleBeforeUnload)
 
-      if (canRoute) {
-        history.block(() => {})
-        history.push(currentPath)
-      }
+      unblockHistoryRef.current = history.block(prompt => {
+        const { pathname, search, state } = prompt
+
+        const isSameRoutePath = matchPath(pathname, {
+          path,
+          exact: true,
+        })
+
+        const hasSameBaseUrl = pathname.startsWith(baseUrlRef.current)
+
+        if ((isSameRoutePath === null && !hasSameBaseUrl) || !hasSameBaseUrl) {
+          setNextPath({ pathname, search, state })
+          setShowPrompt(true)
+          return false
+        }
+
+        return undefined
+      })
+
+      return
     }
-  }, [currentPath, history, onOk])
 
-  const handleCancel = useCallback(async () => {
-    if (onCancel) {
-      const canRoute = await Promise.resolve(onCancel())
-
-      if (canRoute) {
-        history.block(() => {})
-        history.push(currentPath)
-      }
+    if (unblockHistoryRef.current) {
+      unblockHistoryRef.current()
+      window.removeEventListener('beforeunload', handleBeforeUnload)
     }
+  }, [history, when, path])
 
+  const handleOK = useCallback(() => {
+    unblockHistoryRef.current?.()
+    baseUrlRef.current = nextPath.pathname
+    history.push(nextPath)
+  }, [nextPath, history])
+
+  const handleCancel = useCallback(() => {
     setShowPrompt(false)
-  }, [currentPath, history, onCancel])
+  }, [])
 
   return showPrompt ? (
     <Modal
@@ -67,16 +101,12 @@ const RouterPrompt = ({ when, onOk, onCancel, title, okText, cancelText }) => {
 
 RouterPrompt.defaultProps = {
   title: 'Leave this page?',
-  onOk: () => true,
-  onCancel: () => false,
   okText: 'Confirm',
   cancelText: 'Cancel',
 }
 
 RouterPrompt.propTypes = {
   when: PropTypes.bool.isRequired,
-  onOk: PropTypes.func,
-  onCancel: PropTypes.func,
   title: PropTypes.string,
   okText: PropTypes.string,
   cancelText: PropTypes.string,

--- a/packages/client/src/containers/CollectionDropdownMenu/index.jsx
+++ b/packages/client/src/containers/CollectionDropdownMenu/index.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
-import { useHistory, useLocation, useRouteMatch } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
-import { Dropdown, Menu, Skeleton } from 'antd'
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom'
+import { useErrorBoundary } from 'react-error-boundary'
+import { Dropdown, Menu, Skeleton, Empty } from 'antd'
 
 import CollectionItem from '@components/CollectionItem/index'
 
@@ -12,14 +13,25 @@ import {
 } from '@redux/collection/collectionSlice'
 import { getCollectionsByGender } from '@redux/collection/collectionThunk'
 
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
+
 const CollectionDropdownMenu = ({ gender, skeletons }) => {
   const history = useHistory()
   const { pathname, search } = useLocation()
   const match = useRouteMatch('/watches/:type')
   const dispatch = useDispatch()
   const { loading, data } = useSelector(selectCollectionsByGender(gender))
+  const collRef = useRef()
+  const { showBoundary } = useErrorBoundary()
   const [isVisible, setIsVisible] = useState(false)
   const [selectedKeys, setSelectedKeys] = useState([])
+  const [errMsg, setErrMsg] = useState()
+
+  useEffect(() => {
+    return () => {
+      collRef.current?.abort?.('Request Aborted due to component unmount.')
+    }
+  }, [])
 
   useEffect(() => {
     const query = new URLSearchParams(search)
@@ -35,13 +47,28 @@ const CollectionDropdownMenu = ({ gender, skeletons }) => {
     return setSelectedKeys()
   }, [pathname, search, match, gender])
 
-  const handleVisibleChange = visible => {
-    setIsVisible(visible)
+  const handleVisibleChange = useCallback(
+    async visible => {
+      setIsVisible(visible)
 
-    if (visible && !data && !loading) {
-      dispatch(getCollectionsByGender(gender))
-    }
-  }
+      if (visible && !data && !loading) {
+        try {
+          collRef.current = dispatch(getCollectionsByGender(gender))
+          await collRef.current?.unwrap?.()
+        } catch (err) {
+          handleAsyncThunkError(err, showBoundary, {
+            showBoundaryOnlyOnServerError: true,
+          })
+
+          if (err.name !== 'AbortError') {
+            const { data: { message } = { message: undefined } } = err
+            setErrMsg(message)
+          }
+        }
+      }
+    },
+    [dispatch, gender, data, loading, showBoundary]
+  )
 
   return (
     <Dropdown
@@ -105,7 +132,10 @@ const CollectionDropdownMenu = ({ gender, skeletons }) => {
                 />
               ))}
           {!loading && !data?.length && (
-            <div>There is no collections for {gender}</div>
+            <Empty
+              style={{ color: '#fff', padding: '2rem 0' }}
+              description={errMsg || `There is no collections for ${gender}`}
+            />
           )}
         </Menu>
       }>

--- a/packages/client/src/containers/Magnifier/index.jsx
+++ b/packages/client/src/containers/Magnifier/index.jsx
@@ -72,19 +72,32 @@ function getCursorPos(e) {
 }
 
 const handleMouseMove = e => {
-  moveMagnifier(e)
+  const {
+    currentTarget: { firstChild, lastChild },
+  } = e
+
+  if (
+    firstChild.style.display !== 'none' &&
+    !lastChild.classList.contains('loading')
+  ) {
+    moveMagnifier(e)
+  }
 }
 
 const handleOnMouseEnter = e => {
   const { currentTarget: parent } = e
 
-  parent.firstChild.style.display = 'block'
+  if (!parent.lastChild.classList.contains('loading')) {
+    parent.firstChild.style.display = 'block'
+  }
 }
 
 const handleOnMouseLeave = e => {
   const { currentTarget: parent } = e
 
-  parent.firstChild.style.display = 'none'
+  if (!parent.lastChild.classList.contains('loading')) {
+    parent.firstChild.style.display = 'none'
+  }
 }
 
 const Magnifier = forwardRef(({ children }, fowardedRef) => {

--- a/packages/client/src/containers/OffersCarousel/index.jsx
+++ b/packages/client/src/containers/OffersCarousel/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useErrorBoundary } from 'react-error-boundary'
 import { useDispatch, useSelector } from 'react-redux'
 import { Carousel } from 'antd'
 
@@ -7,15 +8,33 @@ import OfferItem from '@components/OfferItem/index'
 import { selectOffers } from '@redux/offer/offerSlice'
 import { getOffers } from '@redux/offer/offerThunk'
 
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
+
 const OffersCarousel = () => {
   const dispatch = useDispatch()
   const offers = useSelector(selectOffers)
+  const { showBoundary } = useErrorBoundary()
 
   useEffect(() => {
-    const getCurrentOffers = () => dispatch(getOffers())
+    let response
+
+    const getCurrentOffers = async () => {
+      try {
+        response = dispatch(getOffers())
+        await response?.unwrap?.()
+      } catch (err) {
+        handleAsyncThunkError(err, showBoundary, {
+          showBoundaryOnlyOnServerError: true,
+        })
+      }
+    }
 
     getCurrentOffers()
-  }, [dispatch])
+
+    return () => {
+      response?.abort?.('Request Aborted due to component unmount.')
+    }
+  }, [dispatch, showBoundary])
 
   return (
     <Carousel

--- a/packages/client/src/containers/ProductPreview/index.jsx
+++ b/packages/client/src/containers/ProductPreview/index.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Link, useHistory } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Skeleton, Button, Rate, Badge, List, Avatar, Comment } from 'antd'
 import { ShoppingCartOutlined, UserOutlined } from '@ant-design/icons'
 
@@ -14,21 +15,27 @@ import {
 import { getProductById } from '@redux/product/productThunk'
 import { addItem } from '@redux/cart/cartSlice'
 
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
+
 const ProductPreview = ({ pid }) => {
   const history = useHistory()
   const dispatch = useDispatch()
   const productForPreview = useSelector(selectProductsByType('preview'))
+  const { showBoundary } = useErrorBoundary()
   const [imgSrc, setImgSrc] = useState('')
   const [imgIsLoading, setImgIsLoading] = useState(true)
   const magnifierRef = useRef()
   const reviewsRef = useRef(null)
 
   useEffect(() => {
-    const fetchProductById = async () => {
-      const response = await dispatch(getProductById(pid))
+    let response
 
-      if (response.error) {
-        history.push('/404')
+    const fetchProductById = async () => {
+      try {
+        response = dispatch(getProductById(pid))
+        await response?.unwrap?.()
+      } catch (err) {
+        handleAsyncThunkError(err, showBoundary)
       }
     }
 
@@ -37,8 +44,9 @@ const ProductPreview = ({ pid }) => {
     return () => {
       setImgSrc('')
       dispatch(clearProductPreview())
+      response?.abort?.('Request Aborted due to component unmount.')
     }
-  }, [history, dispatch, pid])
+  }, [history, dispatch, pid, showBoundary])
 
   return (
     <div className='product-preview'>

--- a/packages/client/src/containers/ProductsPreview/index.jsx
+++ b/packages/client/src/containers/ProductsPreview/index.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types'
+import { useErrorBoundary } from 'react-error-boundary'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
 import { Layout, Skeleton, Pagination, Empty } from 'antd'
@@ -8,6 +9,8 @@ import ProductItem from '@components/ProductItem/index'
 import FilterSiderMenu from '@components/FilterSiderMenu/index'
 
 import { selectProductsByType } from '@redux/product/productSlice'
+
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 
 const { Sider, Content } = Layout
 
@@ -21,26 +24,38 @@ const ProductsPreview = ({
 }) => {
   const dispatch = useDispatch()
   const products = useSelector(selectProductsByType(type))
+  const { showBoundary } = useErrorBoundary()
   const history = useHistory()
   const { pathname } = useLocation()
   const productsRef = useRef(null)
   const [errorResponse, setErrorResponse] = useState('')
 
   useEffect(() => {
+    let response
+
     const getProducts = async () => {
       try {
-        await dispatch(action(params)).unwrap()
+        response = dispatch(action(params))
+        await response?.unwrap?.()
         setErrorResponse('')
       } catch (err) {
-        const {
-          data: { message },
-        } = err
-        setErrorResponse(message)
+        handleAsyncThunkError(err, showBoundary, {
+          showBoundaryOnlyOnServerError: true,
+        })
+
+        if (err.name !== 'AbortError') {
+          const { data: { message } = { message: undefined } } = err
+          setErrorResponse(message)
+        }
       }
     }
 
     getProducts()
-  }, [dispatch, action, params])
+
+    return () => {
+      response?.abort?.('Request Aborted due to component unmount.')
+    }
+  }, [dispatch, action, params, showBoundary])
 
   return (
     <Layout style={{ backgroundColor: '#fff' }}>

--- a/packages/client/src/containers/StatisticCard/index.jsx
+++ b/packages/client/src/containers/StatisticCard/index.jsx
@@ -1,27 +1,52 @@
 import React, { useEffect, useState } from 'react'
+import axios from 'axios'
 import PropTypes from 'prop-types'
+import { useErrorBoundary } from 'react-error-boundary'
+
+import ErrorHandler from '@utils/ErrorHandler'
 
 const StatisticCard = ({ request, children, periodFor, wrapperClassName }) => {
   const [data, setData] = useState()
   const [queryParams, setQueryParams] = useState({ period: periodFor })
   const [loading, setLoading] = useState(false)
+  const { showBoundary } = useErrorBoundary()
 
   useEffect(() => {
+    const source = axios.CancelToken.source()
+
     const fetchData = async () => {
       try {
         setLoading(true)
         const {
           data: { message, ...value },
-        } = await request(queryParams)
+        } = await request(source.token, queryParams)
         setData(value)
         setLoading(false)
       } catch (err) {
-        setLoading(false)
+        if (!axios.isCancel(err) && !err.isAxiosError) {
+          const {
+            status,
+            statusText,
+            data: { error, message },
+          } = err.response
+
+          setLoading(false)
+
+          const boundaryError = new ErrorHandler(message, status, statusText, {
+            cause: error,
+          })
+
+          showBoundary(boundaryError)
+        }
       }
     }
 
     fetchData()
-  }, [request, queryParams])
+
+    return () => {
+      source.cancel('Request Aborted due to component unmount.')
+    }
+  }, [request, queryParams, showBoundary])
 
   return (
     <div className={wrapperClassName}>

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -3,7 +3,9 @@ import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
 import { BrowserRouter as Router } from 'react-router-dom'
+import { ErrorBoundary } from 'react-error-boundary'
 
+import ErrorFallback from '@components/ErrorFallback/index'
 import ScrollToTop from '@components/ScrollToTop/index'
 
 import { store, persistor } from '@redux/store'
@@ -19,7 +21,9 @@ ReactDOM.render(
       <PersistGate loading={null} persistor={persistor}>
         <Router getUserConfirmation={() => {}}>
           <ScrollToTop />
-          <App />
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <App />
+          </ErrorBoundary>
         </Router>
       </PersistGate>
     </Provider>

--- a/packages/client/src/layouts/AuthLayout/index.jsx
+++ b/packages/client/src/layouts/AuthLayout/index.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Layout } from 'antd'
+import { ErrorBoundary } from 'react-error-boundary'
 
+import ErrorFallback from '@components/ErrorFallback/index'
 import FooterContent from '@components/FooterContent/index'
 
 const { Content, Footer } = Layout
@@ -10,7 +12,9 @@ const AuthLayout = ({ children }) => {
   return (
     <Layout style={{ background: 'unset' }}>
       <Content style={{ display: 'flex', justifyContent: 'center' }}>
-        {children}
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+          {children}
+        </ErrorBoundary>
       </Content>
       <Footer
         style={{

--- a/packages/client/src/layouts/DashboardLayout/index.jsx
+++ b/packages/client/src/layouts/DashboardLayout/index.jsx
@@ -7,7 +7,9 @@ import {
   MenuFoldOutlined,
   ExportOutlined,
 } from '@ant-design/icons'
+import { ErrorBoundary } from 'react-error-boundary'
 
+import ErrorFallback from '@components/ErrorFallback/index'
 import FooterContent from '@components/FooterContent/index'
 
 import './styles.scss'
@@ -66,7 +68,11 @@ const DashboardLayout = ({ siderMenu: SiderMenu, children }) => {
             Home
           </Button>
         </Header>
-        <Content style={{ marginTop: '64px' }}>{children}</Content>
+        <Content style={{ marginTop: '64px' }}>
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
+            {children}
+          </ErrorBoundary>
+        </Content>
         <Footer
           style={{ color: 'rgb(168,167,167)', backgroundColor: '#1b2330' }}>
           <FooterContent />

--- a/packages/client/src/layouts/MainLayout/index.jsx
+++ b/packages/client/src/layouts/MainLayout/index.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Layout } from 'antd'
+import { ErrorBoundary } from 'react-error-boundary'
 
 import Navbar from '@components/Navbar/index'
 import FooterContent from '@components/FooterContent/index'
+import ErrorFallback from '@components/ErrorFallback/index'
 
 const { Content, Footer } = Layout
 
@@ -13,7 +15,9 @@ const MainLayout = ({ children }) => {
       <Navbar />
       <Content
         style={{ display: 'flex', flexDirection: 'column', marginTop: '64px' }}>
-        {children}
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+          {children}
+        </ErrorBoundary>
       </Content>
       <Footer
         style={{

--- a/packages/client/src/pages/AddNewProductPage/index.jsx
+++ b/packages/client/src/pages/AddNewProductPage/index.jsx
@@ -42,6 +42,7 @@ const AddNewProductPage = ({ history }) => {
   const [activeTabKey, setActiveTabKey] = useState(undefined)
   const source = axios.CancelToken.source()
   const { showBoundary } = useErrorBoundary()
+  const [existingModels, setExistingModels] = useState([])
 
   useEffect(() => {
     let response
@@ -132,6 +133,9 @@ const AddNewProductPage = ({ history }) => {
 
           if (errors) {
             Object.keys(errors).forEach(err => {
+              if (err === 'model') {
+                setExistingModels(exModels => [...exModels, errors[err].value])
+              }
               setFieldError(err, errors[err].message)
             })
           }
@@ -161,7 +165,7 @@ const AddNewProductPage = ({ history }) => {
         specifications: undefined,
       }}
       onSubmit={handleSubmit}
-      validationSchema={productValidationSchema}>
+      validationSchema={productValidationSchema(existingModels)}>
       {({
         dirty,
         isValid,

--- a/packages/client/src/pages/AddNewProductPage/index.jsx
+++ b/packages/client/src/pages/AddNewProductPage/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import axios from 'axios'
+import { generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { useErrorBoundary } from 'react-error-boundary'
 import { Button, Tabs, Row, Col } from 'antd'
@@ -36,12 +37,12 @@ import './styles.scss'
 const { TabPane } = Tabs
 const { OptGroup, Option } = Select
 
-const AddNewProductPage = ({ history }) => {
+const AddNewProductPage = ({ history, match }) => {
   const dispatch = useDispatch()
   const collections = useSelector(selectCollections)
-  const [activeTabKey, setActiveTabKey] = useState(undefined)
   const source = axios.CancelToken.source()
   const { showBoundary } = useErrorBoundary()
+  const { activeTab } = match.params
   const [existingModels, setExistingModels] = useState([])
 
   useEffect(() => {
@@ -94,7 +95,7 @@ const AddNewProductPage = ({ history }) => {
         )
 
         resetForm()
-        setActiveTabKey('product-info')
+        history.replace(generatePath(match.path))
       } catch (error) {
         if (!axios.isCancel(error) && error.response) {
           const {
@@ -187,7 +188,6 @@ const AddNewProductPage = ({ history }) => {
         <>
           <RouterPrompt when={dirty} />
           <div className='AddNewProductPage'>
-            <div className='caption-background' />
             <div className='caption'>
               <div className='product-preview-wrapper'>
                 <Button
@@ -224,10 +224,16 @@ const AddNewProductPage = ({ history }) => {
               </SubmitButton>
             </div>
             <Tabs
-              defaultActiveKey='product-info'
-              activeKey={activeTabKey}
-              onTabClick={activeKey => setActiveTabKey(activeKey)}>
-              <TabPane key='product-info' tab='Basic Product Info'>
+              defaultActiveKey='info'
+              activeKey={activeTab || 'info'}
+              onTabClick={activeKey => {
+                const generatedPath = generatePath(match.path, {
+                  activeTab: activeKey,
+                })
+
+                history.replace(generatedPath)
+              }}>
+              <TabPane key='info' tab='Basic Product Info'>
                 <Form name='product-info' layout='vertical'>
                   <Row gutter={[16, 8]}>
                     <Col span={8}>
@@ -375,12 +381,12 @@ const AddNewProductPage = ({ history }) => {
                   </Col>
                 </Form>
               </TabPane>
-              <TabPane key='product-images' tab='Product Images'>
+              <TabPane key='images' tab='Product Images'>
                 <Form name='product-images'>
                   <FastField fast name='images' component={DragImagesUpload} />
                 </Form>
               </TabPane>
-              <TabPane key='product-details' tab='Product Details'>
+              <TabPane key='details' tab='Product Details'>
                 <Form name='product-details' layout='vertical'>
                   <Col span={24}>
                     <FastField
@@ -451,6 +457,7 @@ const AddNewProductPage = ({ history }) => {
 
 AddNewProductPage.propTypes = {
   history: PropTypes.instanceOf(Object).isRequired,
+  match: PropTypes.instanceOf(Object).isRequired,
 }
 
 export default AddNewProductPage

--- a/packages/client/src/pages/AddNewProductPage/index.jsx
+++ b/packages/client/src/pages/AddNewProductPage/index.jsx
@@ -1,7 +1,8 @@
-/* eslint-disable no-unused-vars */
 import React, { useEffect, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
+import axios from 'axios'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Button, Tabs, Row, Col } from 'antd'
 import { ArrowLeftOutlined, SaveOutlined } from '@ant-design/icons'
 import { Formik, FastField } from 'formik'
@@ -27,6 +28,9 @@ import {
   PRODUCT_MAIN_FEATURES_OPTIONS,
 } from '@shared/constants'
 
+import ErrorHandler from '@utils/ErrorHandler'
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
+
 import './styles.scss'
 
 const { TabPane } = Tabs
@@ -36,10 +40,29 @@ const AddNewProductPage = ({ history }) => {
   const dispatch = useDispatch()
   const collections = useSelector(selectCollections)
   const [activeTabKey, setActiveTabKey] = useState(undefined)
+  const source = axios.CancelToken.source()
+  const { showBoundary } = useErrorBoundary()
 
   useEffect(() => {
-    dispatch(getCollections())
-  }, [dispatch])
+    let response
+
+    const fetchCollections = async () => {
+      try {
+        response = dispatch(getCollections())
+        await response?.unwrap?.()
+      } catch (err) {
+        handleAsyncThunkError(err, showBoundary)
+      }
+    }
+
+    fetchCollections()
+
+    return () => {
+      response?.abort?.('Request Aborted due to component unmount.')
+      source.cancel('Request Aborted due to component unmount.')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, showBoundary])
 
   const handleSubmit = useCallback(
     async (values, { setFieldError, resetForm }) => {
@@ -58,7 +81,7 @@ const AddNewProductPage = ({ history }) => {
 
         const {
           data: { message },
-        } = await createNewProduct(data)
+        } = await createNewProduct(data, source.token)
 
         dispatch(
           createNotification({
@@ -71,32 +94,52 @@ const AddNewProductPage = ({ history }) => {
 
         resetForm()
         setActiveTabKey('product-info')
-      } catch ({ response }) {
-        const {
-          status,
-          statusText,
-          data: { errors, message },
-        } = response
+      } catch (error) {
+        if (!axios.isCancel(error) && error.response) {
+          const {
+            status,
+            statusText,
+            data: { errors, message },
+          } = error.response
 
-        dispatch(
-          createNotification({
-            id: 'newProductCreatedError',
-            type: 'error',
-            title: `Error, ${statusText}`,
-            description:
-              message ||
-              'Something went wrong while creating a new product, please try again later.',
-          })
-        )
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(
+              message,
+              status,
+              statusText,
+              {
+                redirect: {
+                  to: '/admin/e-commerce/products',
+                  text: 'Back to Products',
+                },
+              }
+            )
 
-        if (errors) {
-          Object.keys(errors).forEach(err => {
-            setFieldError(err, errors[err].message)
-          })
+            showBoundary(boundaryError)
+            return
+          }
+
+          dispatch(
+            createNotification({
+              id: 'newProductCreatedError',
+              type: 'error',
+              title: `Error, ${statusText}`,
+              description:
+                message ||
+                'Something went wrong while creating a new product, please try again later.',
+            })
+          )
+
+          if (errors) {
+            Object.keys(errors).forEach(err => {
+              setFieldError(err, errors[err].message)
+            })
+          }
         }
       }
     },
-    [dispatch]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dispatch, showBoundary, source.token]
   )
 
   return (
@@ -121,7 +164,6 @@ const AddNewProductPage = ({ history }) => {
       validationSchema={productValidationSchema}>
       {({
         dirty,
-        errors,
         isValid,
         handleSubmit: submitForm,
         setFieldValue,
@@ -186,6 +228,7 @@ const AddNewProductPage = ({ history }) => {
                   <Row gutter={[16, 8]}>
                     <Col span={8}>
                       <FastField
+                        fast
                         required
                         size='large'
                         name='name'
@@ -195,6 +238,7 @@ const AddNewProductPage = ({ history }) => {
                     </Col>
                     <Col span={8}>
                       <FastField
+                        fast
                         required
                         size='large'
                         name='model'
@@ -204,6 +248,7 @@ const AddNewProductPage = ({ history }) => {
                     </Col>
                     <Col span={8}>
                       <FastField
+                        fast
                         required
                         size='large'
                         name='collectionName'
@@ -244,6 +289,7 @@ const AddNewProductPage = ({ history }) => {
                   <Row gutter={[16, 8]}>
                     <Col span={4}>
                       <FastField
+                        fast
                         required
                         size='large'
                         name='color'
@@ -257,6 +303,7 @@ const AddNewProductPage = ({ history }) => {
                     </Col>
                     <Col span={8}>
                       <FastField
+                        fast
                         required
                         size='large'
                         style={{ width: '100%' }}
@@ -274,6 +321,7 @@ const AddNewProductPage = ({ history }) => {
                     </Col>
                     <Col span={4}>
                       <FastField
+                        fast
                         required
                         size='large'
                         style={{ width: '100%' }}
@@ -291,6 +339,7 @@ const AddNewProductPage = ({ history }) => {
                     </Col>
                     <Col span={8}>
                       <FastField
+                        fast
                         required
                         size='large'
                         style={{ width: '100%' }}
@@ -310,6 +359,7 @@ const AddNewProductPage = ({ history }) => {
                   </Row>
                   <Col span={24}>
                     <FastField
+                      fast
                       required
                       rows={6}
                       size='large'
@@ -323,13 +373,14 @@ const AddNewProductPage = ({ history }) => {
               </TabPane>
               <TabPane key='product-images' tab='Product Images'>
                 <Form name='product-images'>
-                  <FastField name='images' component={DragImagesUpload} />
+                  <FastField fast name='images' component={DragImagesUpload} />
                 </Form>
               </TabPane>
               <TabPane key='product-details' tab='Product Details'>
                 <Form name='product-details' layout='vertical'>
                   <Col span={24}>
                     <FastField
+                      fast
                       required
                       showArrow
                       mode='tags'
@@ -344,6 +395,7 @@ const AddNewProductPage = ({ history }) => {
                   </Col>
                   <Col span={24}>
                     <FastField
+                      fast
                       required
                       showArrow
                       mode='tags'
@@ -358,6 +410,7 @@ const AddNewProductPage = ({ history }) => {
                   </Col>
                   <Col span={24}>
                     <FastField
+                      fast
                       required
                       showArrow
                       mode='tags'
@@ -372,6 +425,7 @@ const AddNewProductPage = ({ history }) => {
                   </Col>
                   <Col span={24}>
                     <FastField
+                      fast
                       required
                       rows={6}
                       size='large'

--- a/packages/client/src/pages/AddNewProductPage/styles.scss
+++ b/packages/client/src/pages/AddNewProductPage/styles.scss
@@ -3,22 +3,23 @@
   padding: 0 2rem;
   margin-bottom: 2rem;
 
-  .caption-background {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 233px;
-    background: linear-gradient(to right, #1b2330 0%, #252f3e 100%);
-    background-size: cover;
-    pointer-events: none;
-  }
-
   .caption {
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 37px 0;
+
+    &::before {
+      content: '';
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: -1;
+      height: 233px;
+      position: absolute;
+      pointer-events: none;
+      background: linear-gradient(to right, #1b2330 0%, #252f3e 100%);
+    }
   }
 
   .product-preview-wrapper {

--- a/packages/client/src/pages/AddNewUserPage/index.jsx
+++ b/packages/client/src/pages/AddNewUserPage/index.jsx
@@ -1,6 +1,8 @@
-import React, { useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
+import axios from 'axios'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Formik, Field } from 'formik'
 import { Form, FormItem, SubmitButton } from 'formik-antd'
 import { Row, Col, Button, Checkbox, Tabs } from 'antd'
@@ -14,14 +16,25 @@ import { signup as createNewUser } from '@api/user/auth'
 import { signupValidationSchema } from '@validation/user-validation'
 import { create as createNotification } from '@redux/notification/notificationSlice'
 
+import ErrorHandler from '@utils/ErrorHandler'
+
 import './styles.scss'
 
 const { TabPane } = Tabs
 
 const AddNewUserPage = ({ history }) => {
   const dispatch = useDispatch()
+  const source = axios.CancelToken.source()
+  const { showBoundary } = useErrorBoundary()
   const [existingUserNames, setExistingUserNames] = useState([])
   const [existingEmails, setExistingEmails] = useState([])
+
+  useEffect(() => {
+    return () => {
+      source.cancel('Request Aborted due to component unmount.')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleSubmit = useCallback(
     async (values, { resetForm, setFieldError }) => {
@@ -34,7 +47,7 @@ const AddNewUserPage = ({ history }) => {
       try {
         const {
           data: { message },
-        } = await createNewUser(data, '/createNewUser')
+        } = await createNewUser(data, source.token, '/createNewUser')
 
         dispatch(
           createNotification({
@@ -48,9 +61,22 @@ const AddNewUserPage = ({ history }) => {
         resetForm()
       } catch (error) {
         const {
+          status,
           statusText,
           data: { errors, message },
         } = error.response
+
+        if (status === 500) {
+          const boundaryError = new ErrorHandler(message, status, statusText, {
+            redirect: {
+              to: '/admin/users',
+              text: 'Back to Users',
+            },
+          })
+
+          showBoundary(boundaryError)
+          return
+        }
 
         dispatch(
           createNotification({
@@ -79,7 +105,7 @@ const AddNewUserPage = ({ history }) => {
         }
       }
     },
-    [dispatch]
+    [dispatch, showBoundary, source.token]
   )
 
   return (

--- a/packages/client/src/pages/AddNewUserPage/index.jsx
+++ b/packages/client/src/pages/AddNewUserPage/index.jsx
@@ -135,7 +135,6 @@ const AddNewUserPage = ({ history }) => {
           <>
             <RouterPrompt when={dirty} />
             <div className='AddNewUserPage'>
-              <div className='caption-background' />
               <div className='caption'>
                 <div className='user-preview-wrapper'>
                   <Button

--- a/packages/client/src/pages/AddNewUserPage/styles.scss
+++ b/packages/client/src/pages/AddNewUserPage/styles.scss
@@ -10,22 +10,23 @@
     position: relative;
     padding: 0 2rem 2rem;
 
-    .caption-background {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 288px;
-      background-size: cover;
-      background: linear-gradient(to right, #1b2330 0%, #252f3e 100%);
-      pointer-events: none;
-    }
-
     .caption {
       display: flex;
       align-items: center;
       justify-content: space-between;
       padding: 37px 0;
+
+      &::before {
+        content: '';
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: -1;
+        height: 288px;
+        position: absolute;
+        pointer-events: none;
+        background: linear-gradient(to right, #1b2330 0%, #252f3e 100%);
+      }
     }
 
     .ant-tabs-nav-wrap {

--- a/packages/client/src/pages/AdminPanelPage/index.jsx
+++ b/packages/client/src/pages/AdminPanelPage/index.jsx
@@ -1,8 +1,8 @@
 import React, { useLayoutEffect, lazy, Suspense } from 'react'
-import { Switch, Route } from 'react-router-dom'
+import { Switch, Route, Link } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Spin } from 'antd'
+import { Spin, Result } from 'antd'
 
 import { selectLoggedInUser } from '@redux/user/userSlice'
 
@@ -17,7 +17,7 @@ const AdminPanelPage = ({ history }) => {
 
   useLayoutEffect(() => {
     if (!loggedInUser.info?.isAdmin)
-      history.push(`/users/${loggedInUser.info.id}/profile`)
+      history.replace(`/users/${loggedInUser.info.id}/profile`)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -59,6 +59,23 @@ const AdminPanelPage = ({ history }) => {
           exact
           path='/admin/profile/:activeTab?'
           component={UserProfilePage}
+        />
+        <Route
+          path='*'
+          render={() => (
+            <Result
+              style={{ margin: 'auto' }}
+              status={404}
+              title={
+                <>
+                  <strong>404</strong>
+                  <p>Page Not Found</p>
+                </>
+              }
+              subTitle="The page you are looking for doesn't exists."
+              extra={<Link to='/admin/dashboard'>Back to Dashboard</Link>}
+            />
+          )}
         />
       </Switch>
     </Suspense>

--- a/packages/client/src/pages/CheckoutShippingPage/index.jsx
+++ b/packages/client/src/pages/CheckoutShippingPage/index.jsx
@@ -1,8 +1,10 @@
-import React, { useLayoutEffect, useEffect, useRef } from 'react'
+import React, { useLayoutEffect, useEffect, useRef, useCallback } from 'react'
+import axios from 'axios'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import { withFormik, Field } from 'formik'
+import { useDispatch } from 'react-redux'
+import { useFormik, FormikProvider, Field } from 'formik'
 import { Form, FormItem, SubmitButton } from 'formik-antd'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Checkbox } from 'antd'
 import { MailOutlined, CarOutlined, DollarOutlined } from '@ant-design/icons'
 
@@ -10,20 +12,123 @@ import InputField from '@components/InputField/index'
 
 import { createNewOrder } from '@api/order/index'
 import orderValidationSchema from '@validation/order-validation'
-import { removeAll } from '@redux/cart/cartSlice'
+
+import { removeAll as clearCartItems } from '@redux/cart/cartSlice'
 import { create as createNotification } from '@redux/notification/notificationSlice'
+
+import ErrorHandler from '@utils/ErrorHandler'
 
 import './styles.scss'
 
-const ShippingPage = ({
-  dirty,
-  isValid,
-  values: formikValues,
-  setValues,
-  setTouched,
-  setFieldValue,
+const CheckoutShippingPage = ({
+  history,
+  cartItems,
+  stepDispatch,
+  loggedInUserEmail,
 }) => {
   const isMounted = useRef()
+  const dispatch = useDispatch()
+  const source = axios.CancelToken.source()
+  const { showBoundary } = useErrorBoundary()
+
+  const handleSubmit = useCallback(
+    async (values, { setFieldError, resetForm }) => {
+      const { sameAddr, ...newOrderValues } = values
+      const items = cartItems.map(({ id, quantity }) => ({
+        id,
+        quantity,
+      }))
+
+      try {
+        const {
+          data: { createdOrder, message },
+        } = await createNewOrder({ items, ...newOrderValues }, source.token)
+
+        dispatch(
+          createNotification({
+            id: 'newOrderCreatedSuccess',
+            type: 'success',
+            title: 'Success!',
+            description: message,
+          })
+        )
+
+        resetForm()
+        dispatch(clearCartItems())
+
+        stepDispatch({
+          type: 'STATUS',
+          payload: { key: 'checkout', status: 'finish' },
+        })
+
+        stepDispatch({
+          type: 'STATUS',
+          payload: { key: 'shipping', status: 'finish' },
+        })
+
+        stepDispatch({
+          type: 'AVAILABLE',
+          payload: { key: 'finish', disabled: false },
+        })
+
+        history.push('/checkout/finish', { createdOrder })
+      } catch (error) {
+        if (!axios.isCancel(error) && error.response) {
+          const {
+            status,
+            statusText,
+            data: { errors, message },
+          } = error.response
+
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(message, status, statusText)
+
+            showBoundary(boundaryError)
+            return
+          }
+
+          if (errors) {
+            Object.keys(errors).forEach(err => {
+              setFieldError(err, errors[err].message)
+            })
+            return
+          }
+
+          dispatch(
+            createNotification({
+              id: 'newOrderCreatedError',
+              type: 'error',
+              title: `Error, ${statusText}`,
+              description:
+                message ||
+                'Something went wrong while creating an order, please try again later.',
+            })
+          )
+        }
+      }
+    },
+    [history, dispatch, stepDispatch, cartItems, showBoundary, source.token]
+  )
+
+  const formikProps = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      email: '',
+      address: { shipping: '', billing: '' },
+      sameAddr: false,
+    },
+    validationSchema: orderValidationSchema(loggedInUserEmail),
+    onSubmit: handleSubmit,
+  })
+
+  const {
+    dirty,
+    isValid,
+    values: formikValues,
+    setValues,
+    setTouched,
+    setFieldValue,
+  } = formikProps
 
   useLayoutEffect(() => {
     isMounted.current = true
@@ -35,6 +140,7 @@ const ShippingPage = ({
             sessionStorage.getItem('shippingDetails')
           )
           await setValues(updatedValues)
+
           const updatedTouchValues = Object.keys(updatedValues).reduce(
             (acc, key) => {
               if (
@@ -67,6 +173,7 @@ const ShippingPage = ({
 
     return () => {
       isMounted.current = false
+      source.cancel('Request Aborted due to component unmount.')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -82,150 +189,60 @@ const ShippingPage = ({
   return (
     <div className='CheckoutShippingPage'>
       <h1 className='shipping-title'>Shipping Details</h1>
-      <Form size='large' layout='vertical' className='shipping-details-form'>
-        <Field
-          name='email'
-          type='email'
-          prefix={<MailOutlined className='site-form-item-icon' />}
-          placeholder='Additional email address'
-          component={InputField}
-        />
-        <Field
-          name='address.shipping'
-          prefix={<CarOutlined className='site-form-item-icon' />}
-          placeholder='Shipping Address'
-          component={InputField}
-        />
-        <Field
-          name='address.billing'
-          prefix={<DollarOutlined className='site-form-item-icon' />}
-          placeholder='Billing Address'
-          component={InputField}
-        />
-        <FormItem name='sameAddr' noStyle>
-          <Checkbox
-            name='sameAddr'
-            checked={formikValues.sameAddr}
-            defaultChecked={formikValues.sameAddr}
-            onChange={e => {
-              setFieldValue('sameAddr', e.target.checked)
-              if (e.target.checked) {
-                setFieldValue('address.billing', formikValues.address.shipping)
-              }
-            }}>
-            Same shipping and billing address
-          </Checkbox>
-        </FormItem>
-        <SubmitButton
-          style={{ marginTop: '1rem', textTransform: 'capitalize' }}
-          disabled={!dirty || !isValid}>
-          Create an order
-        </SubmitButton>
-      </Form>
+      <FormikProvider value={formikProps}>
+        <Form size='large' layout='vertical' className='shipping-details-form'>
+          <Field
+            name='email'
+            type='email'
+            prefix={<MailOutlined className='site-form-item-icon' />}
+            placeholder='Additional email address'
+            component={InputField}
+          />
+          <Field
+            name='address.shipping'
+            prefix={<CarOutlined className='site-form-item-icon' />}
+            placeholder='Shipping Address'
+            component={InputField}
+          />
+          <Field
+            name='address.billing'
+            prefix={<DollarOutlined className='site-form-item-icon' />}
+            placeholder='Billing Address'
+            component={InputField}
+          />
+          <FormItem name='sameAddr' noStyle>
+            <Checkbox
+              name='sameAddr'
+              checked={formikValues.sameAddr}
+              defaultChecked={formikValues.sameAddr}
+              onChange={e => {
+                setFieldValue('sameAddr', e.target.checked)
+                if (e.target.checked) {
+                  setFieldValue(
+                    'address.billing',
+                    formikValues.address.shipping
+                  )
+                }
+              }}>
+              Same shipping and billing address
+            </Checkbox>
+          </FormItem>
+          <SubmitButton
+            style={{ marginTop: '1rem', textTransform: 'capitalize' }}
+            disabled={!dirty || !isValid}>
+            Create an order
+          </SubmitButton>
+        </Form>
+      </FormikProvider>
     </div>
   )
 }
 
-ShippingPage.propTypes = {
-  dirty: PropTypes.bool.isRequired,
-  isValid: PropTypes.bool.isRequired,
-  values: PropTypes.instanceOf(Object).isRequired,
-  setValues: PropTypes.func.isRequired,
-  setTouched: PropTypes.func.isRequired,
-  setFieldValue: PropTypes.func.isRequired,
+CheckoutShippingPage.propTypes = {
+  history: PropTypes.instanceOf(Object).isRequired,
+  cartItems: PropTypes.arrayOf(Object).isRequired,
+  stepDispatch: PropTypes.func.isRequired,
+  loggedInUserEmail: PropTypes.string.isRequired,
 }
-
-const mapDispatchToProps = dispatch => ({
-  dispatchNotification: notification =>
-    dispatch(createNotification(notification)),
-  clearCartItems: () => dispatch(removeAll()),
-})
-
-const CheckoutShippingPage = connect(
-  null,
-  mapDispatchToProps
-)(
-  withFormik({
-    displayName: 'CheckoutShippingPage',
-    enableReinitialize: true,
-    validationSchema: ({ loggedInUserEmail }) =>
-      orderValidationSchema(loggedInUserEmail),
-    mapPropsToValues: () => {
-      const initialState = {
-        email: '',
-        address: { shipping: '', billing: '' },
-        sameAddr: false,
-      }
-      return initialState
-    },
-    handleSubmit: async (values, { props, setFieldError, resetForm }) => {
-      const { sameAddr, ...newOrderValues } = values
-      const {
-        history,
-        cartItems,
-        stepDispatch,
-        dispatchNotification,
-        clearCartItems,
-      } = props
-      const items = cartItems.map(({ id, quantity }) => ({
-        id,
-        quantity,
-      }))
-
-      try {
-        const {
-          data: { createdOrder, message },
-        } = await createNewOrder({ items, ...newOrderValues })
-
-        dispatchNotification({
-          id: 'newOrderCreatedSuccess',
-          type: 'success',
-          title: 'Success!',
-          description: message,
-        })
-
-        resetForm()
-        clearCartItems()
-
-        stepDispatch({
-          type: 'STATUS',
-          payload: { key: 'checkout', status: 'finish' },
-        })
-
-        stepDispatch({
-          type: 'STATUS',
-          payload: { key: 'shipping', status: 'finish' },
-        })
-
-        stepDispatch({
-          type: 'AVAILABLE',
-          payload: { key: 'finish', disabled: false },
-        })
-
-        history.push('/checkout/finish', { createdOrder })
-      } catch ({ response }) {
-        const {
-          statusText,
-          data: { errors, message },
-        } = response
-
-        if (errors) {
-          Object.keys(errors).forEach(err => {
-            setFieldError(err, errors[err].message)
-          })
-        } else {
-          dispatchNotification({
-            id: 'newOrderCreatedError',
-            type: 'error',
-            title: `Error, ${statusText}`,
-            description:
-              message ||
-              'Something went wrong while creating an order, please try again later.',
-          })
-        }
-      }
-    },
-  })(ShippingPage)
-)
 
 export default CheckoutShippingPage

--- a/packages/client/src/pages/DashboardPage/index.jsx
+++ b/packages/client/src/pages/DashboardPage/index.jsx
@@ -1,6 +1,4 @@
-/* eslint-disable no-unused-vars */
 import React from 'react'
-import PropTypes from 'prop-types'
 import { Row, Col } from 'antd'
 import { AppstoreOutlined, ShoppingCartOutlined } from '@ant-design/icons'
 import Icon from '@ant-design/icons/lib/components/Icon'
@@ -20,7 +18,7 @@ import './styles.scss'
 
 const UsersOutlined = props => <Icon {...props} component={UsersIcon} />
 
-const DashboardPage = ({ history }) => {
+const DashboardPage = () => {
   return (
     <div className='DashboardPage'>
       <Row gutter={8}>
@@ -85,7 +83,7 @@ const DashboardPage = ({ history }) => {
             request={getTotalOrdersSales}
             periodFor='last-six-months'
             wrapperClassName='area-chart-card'>
-            {({ data: { totalSales } = {}, loading }) => (
+            {({ data: { totalSales } = {} }) => (
               <AreaChart data={totalSales?.[0]?.data} dataKey='total.amount' />
             )}
           </StatisticCard>
@@ -93,10 +91,6 @@ const DashboardPage = ({ history }) => {
       </Row>
     </div>
   )
-}
-
-DashboardPage.propTypes = {
-  history: PropTypes.instanceOf(Object).isRequired,
 }
 
 export default DashboardPage

--- a/packages/client/src/pages/DataOverviewPage/index.jsx
+++ b/packages/client/src/pages/DataOverviewPage/index.jsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react'
 import PropTypes from 'prop-types'
 import { parse, stringify } from 'qs'
-import { useLocation } from 'react-router-dom'
+import { useLocation, useRouteMatch } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { useErrorBoundary } from 'react-error-boundary'
 import { Table, Input, Button, Empty } from 'antd'
@@ -30,7 +30,8 @@ const DataOverviewPage = ({
 }) => {
   const dispatch = useDispatch()
   const selectedInfo = useSelector(selector)
-  const { pathname, search } = useLocation()
+  const { search } = useLocation()
+  const { path } = useRouteMatch()
   const { showBoundary } = useErrorBoundary()
   const searchQueryParam = useRef('')
   const [errMsg, setErrMsg] = useState('')
@@ -127,7 +128,6 @@ const DataOverviewPage = ({
 
   return (
     <div className='DataOverviewPage'>
-      <div className='caption-background' />
       <div className='caption'>
         <h1 className='title'>{title}</h1>
         <Search
@@ -145,7 +145,7 @@ const DataOverviewPage = ({
             type='primary'
             size='large'
             icon={addNewIcon}
-            onClick={() => history.push(`${pathname}/create`)}>
+            onClick={() => history.push(`${path}/create`)}>
             Add New {dataAbout.charAt(0).toUpperCase() + dataAbout.slice(1)}
           </Button>
         )}
@@ -157,10 +157,12 @@ const DataOverviewPage = ({
           rowClassName='data-overview-row'
           columns={defaultColumns || columns}
           loading={selectedInfo.loading}
-          dataSource={selectedInfo.data}
+          dataSource={selectedInfo.loading ? undefined : selectedInfo.data}
           locale={{
             emptyText: selectedInfo.loading ? (
-              <p style={{ fontSize: '1.2rem' }}>Loading {dataAbout}s data...</p>
+              <p style={{ fontSize: '1.2rem' }}>
+                Loading {dataAbout}&apos;s data...
+              </p>
             ) : (
               <Empty
                 image='https://gw.alipayobjects.com/zos/antfincdn/ZHrcdLPrvN/empty.svg'
@@ -191,7 +193,7 @@ const DataOverviewPage = ({
           }}
           onRow={({ id }) => {
             return {
-              onClick: () => history.push(`${pathname}/${id}`),
+              onClick: () => history.push(`${path}/${id}`),
             }
           }}
           onChange={({ current, pageSize }, filters, sorters) => {

--- a/packages/client/src/pages/DataOverviewPage/index.jsx
+++ b/packages/client/src/pages/DataOverviewPage/index.jsx
@@ -9,7 +9,10 @@ import PropTypes from 'prop-types'
 import { parse, stringify } from 'qs'
 import { useLocation } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Table, Input, Button, Empty } from 'antd'
+
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 
 import './styles.scss'
 
@@ -26,12 +29,13 @@ const DataOverviewPage = ({
   selector,
 }) => {
   const dispatch = useDispatch()
+  const selectedInfo = useSelector(selector)
   const { pathname, search } = useLocation()
+  const { showBoundary } = useErrorBoundary()
   const searchQueryParam = useRef('')
   const [errMsg, setErrMsg] = useState('')
   const [defaultColumns, setDefaultColumns] = useState()
   const [defaultSearchValue, setDefaultSearchValue] = useState('')
-  const selectedInfo = useSelector(selector)
 
   useLayoutEffect(() => {
     const urlSearchQueryParams = parse(search, { ignoreQueryPrefix: true })
@@ -64,23 +68,32 @@ const DataOverviewPage = ({
   }, [])
 
   useEffect(() => {
+    let response
+
     const fetchData = async () => {
       try {
         const urlSearchQueryParams = parse(search, { ignoreQueryPrefix: true })
-        await dispatch(action(urlSearchQueryParams)).unwrap()
+        response = dispatch(action(urlSearchQueryParams))
+        await response?.unwrap?.()
       } catch (err) {
-        const {
-          data: { message },
-        } = err
+        handleAsyncThunkError(err, showBoundary, {
+          showBoundaryOnlyOnServerError: true,
+        })
 
-        if (err.status !== 'ABORTED') {
+        if (!err.name || err.name !== 'AbortError') {
+          const { data: { message } = { message: undefined } } = err
+
           setErrMsg(message)
         }
       }
     }
 
     fetchData()
-  }, [action, dispatch, search])
+
+    return () => {
+      response?.abort?.('Request Aborted due to component unmount.')
+    }
+  }, [action, dispatch, search, showBoundary])
 
   const handleOnSearch = useCallback(
     (value, event) => {

--- a/packages/client/src/pages/DataOverviewPage/styles.scss
+++ b/packages/client/src/pages/DataOverviewPage/styles.scss
@@ -3,22 +3,23 @@
   padding: 0 2rem;
   margin-bottom: 2rem;
 
-  .caption-background {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 233px;
-    background: linear-gradient(to right, #1b2330 0%, #252f3e 100%);
-    background-size: cover;
-    pointer-events: none;
-  }
-
   .caption {
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 4rem 0;
+
+    &::before {
+      content: '';
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: -1;
+      height: 233px;
+      position: absolute;
+      pointer-events: none;
+      background: linear-gradient(to right, #1b2330 0%, #252f3e 100%);
+    }
 
     .title {
       display: flex;

--- a/packages/client/src/pages/ForgotPasswordPage/index.jsx
+++ b/packages/client/src/pages/ForgotPasswordPage/index.jsx
@@ -8,6 +8,7 @@ import { Formik, Field } from 'formik'
 import { Form, SubmitButton } from 'formik-antd'
 
 import InputField from '@components/InputField/index'
+import RouterPrompt from '@components/RouterPrompt/index'
 
 import { forgotPassword } from '@api/user/auth'
 import { forgotPassValidationSchema } from '@validation/user-validation'
@@ -110,24 +111,27 @@ const ForgotPasswordPage = () => {
               errMsg
             )}>
             {({ dirty, isValid }) => (
-              <Form layout='vertical' size='large'>
-                <Field
-                  name='userNameOrEmail'
-                  prefix={<UserOutlined className='site-form-item-icon' />}
-                  placeholder='Username or Email address'
-                  component={InputField}
-                />
-                <Form.Item name='forgotPassword'>
-                  <SubmitButton block disabled={!dirty || !isValid}>
-                    Send request
-                  </SubmitButton>
-                </Form.Item>
-                <Form.Item name='signin' noStyle>
-                  <span className='signin-caption'>
-                    Go back to <Link to='/auth/signin'>Sign In</Link>
-                  </span>
-                </Form.Item>
-              </Form>
+              <>
+                <RouterPrompt when={dirty} />
+                <Form layout='vertical' size='large'>
+                  <Field
+                    name='userNameOrEmail'
+                    prefix={<UserOutlined className='site-form-item-icon' />}
+                    placeholder='Username or Email address'
+                    component={InputField}
+                  />
+                  <Form.Item name='forgotPassword'>
+                    <SubmitButton block disabled={!dirty || !isValid}>
+                      Send request
+                    </SubmitButton>
+                  </Form.Item>
+                  <Form.Item name='signin' noStyle>
+                    <span className='signin-caption'>
+                      Go back to <Link to='/auth/signin'>Sign In</Link>
+                    </span>
+                  </Form.Item>
+                </Form>
+              </>
             )}
           </Formik>
         </Card>

--- a/packages/client/src/pages/ForgotPasswordPage/index.jsx
+++ b/packages/client/src/pages/ForgotPasswordPage/index.jsx
@@ -1,5 +1,7 @@
-import React, { useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
+import axios from 'axios'
 import { Link } from 'react-router-dom'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Card, Alert } from 'antd'
 import { UserOutlined } from '@ant-design/icons'
 import { Formik, Field } from 'formik'
@@ -9,19 +11,29 @@ import InputField from '@components/InputField/index'
 
 import { forgotPassword } from '@api/user/auth'
 import { forgotPassValidationSchema } from '@validation/user-validation'
+import ErrorHandler from '@utils/ErrorHandler'
 
 import './styles.scss'
 
 const ForgotPasswordPage = () => {
   const [errMsg, setErrMsg] = useState('')
   const [nonExistingUsers, setNonExistingUsers] = useState([])
-  const [serverResponse, setServerResponse] = useState({})
+  const [serverResponse, setServerResponse] = useState()
+  const source = axios.CancelToken.source()
+  const { showBoundary } = useErrorBoundary()
+
+  useEffect(() => {
+    return () => {
+      source.cancel('Request Aborted due to component unmount.')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleSubmit = useCallback(
     async (values, { setFieldError, resetForm }) => {
-      setServerResponse({})
+      setServerResponse()
       try {
-        const response = await forgotPassword(values)
+        const response = await forgotPassword(values, source.token)
         const {
           status,
           data: { message },
@@ -29,22 +41,33 @@ const ForgotPasswordPage = () => {
 
         setServerResponse({ status, message })
         resetForm()
-      } catch ({ response }) {
-        const {
-          status,
-          statusText,
-          data: { errors, message },
-        } = response
+      } catch (error) {
+        if (!axios.isCancel(error) && error.response) {
+          const {
+            response: {
+              status,
+              statusText,
+              data: { errors, message },
+            },
+          } = error
 
-        if (errors) {
-          Object.keys(errors).forEach(err => {
-            setFieldError(err, errors[err].message)
-            if (err === 'userNameOrEmail') {
-              setErrMsg(errors[err].message)
-              setNonExistingUsers(users => [...users, errors[err].value])
-            }
-          })
-        } else {
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(message, status, statusText)
+            showBoundary(boundaryError)
+            return
+          }
+
+          if (errors) {
+            Object.keys(errors).forEach(err => {
+              setFieldError(err, errors[err].message)
+              if (err === 'userNameOrEmail') {
+                setErrMsg(errors[err].message)
+                setNonExistingUsers(users => [...users, errors[err].value])
+              }
+            })
+            return
+          }
+
           setServerResponse({
             status,
             statusText,
@@ -53,13 +76,13 @@ const ForgotPasswordPage = () => {
         }
       }
     },
-    []
+    [showBoundary, source.token]
   )
 
   return (
     <>
       <div className='ForgotpasswordPage'>
-        {Object.keys(serverResponse).length > 0 && (
+        {serverResponse && (
           <Alert
             type={serverResponse.status >= 400 ? 'error' : 'success'}
             message={

--- a/packages/client/src/pages/ForgotPasswordPage/styles.scss
+++ b/packages/client/src/pages/ForgotPasswordPage/styles.scss
@@ -7,13 +7,16 @@
 
   & div.ant-card.ant-card-bordered {
     width: 400px;
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 15px;
+    overflow: hidden;
+    border-radius: 1rem;
+    border-color: #1b2330;
 
     div.ant-card-head {
       text-align: center;
+      background-color: #1b2330;
 
       & div.ant-card-head-title {
+        color: #fff;
         padding: 1.5rem 0;
         font-size: 1.7rem;
       }

--- a/packages/client/src/pages/OrdersPage/index.jsx
+++ b/packages/client/src/pages/OrdersPage/index.jsx
@@ -1,10 +1,12 @@
 import React, { lazy } from 'react'
-import { Switch, Route, useRouteMatch } from 'react-router-dom'
+import { Switch, Route, useRouteMatch, Link } from 'react-router-dom'
+import { Result } from 'antd'
 
-import { ORDERS_COLUMNS } from '@shared/constants'
 import { selectAllOrders } from '@redux/order/orderSlice'
 import { getOrders } from '@redux/order/orderThunk'
+
 import OrdersIcon from '@assets/orders-icon.png'
+import { ORDERS_COLUMNS } from '@shared/constants'
 
 const DataOverviewPage = lazy(() => import('@pages/DataOverviewPage/index'))
 const UpdateOrderPage = lazy(() => import('@pages/UpdateOrderPage/index'))
@@ -51,6 +53,23 @@ const OrdersPage = () => {
         exact
         path={`${path}/:oid/:activeTab?`}
         component={UpdateOrderPage}
+      />
+      <Route
+        path='*'
+        render={() => (
+          <Result
+            style={{ margin: 'auto' }}
+            status={404}
+            title={
+              <>
+                <strong>404</strong>
+                <p>Page Not Found</p>
+              </>
+            }
+            subTitle="The page you are looking for doesn't exists."
+            extra={<Link to='/admin/e-commerce/orders'>Back to Orders</Link>}
+          />
+        )}
       />
     </Switch>
   )

--- a/packages/client/src/pages/ProductsPage/index.jsx
+++ b/packages/client/src/pages/ProductsPage/index.jsx
@@ -1,5 +1,6 @@
 import React, { lazy } from 'react'
-import { Switch, Route, useRouteMatch } from 'react-router-dom'
+import { Switch, Route, useRouteMatch, Link } from 'react-router-dom'
+import { Result } from 'antd'
 import { AppstoreOutlined, AppstoreAddOutlined } from '@ant-design/icons'
 
 import { PRODUCT_COLUMNS } from '@shared/constants'
@@ -46,11 +47,32 @@ const ProductsPage = () => {
           />
         )}
       />
-      <Route exact path={`${path}/create`} component={AddNewProductPage} />
+      <Route
+        exact
+        path={`${path}/create/:activeTab?`}
+        component={AddNewProductPage}
+      />
       <Route
         exact
         path={`${path}/:pid/:activeTab?`}
         component={UpdateProductPage}
+      />
+      <Route
+        path='*'
+        render={() => (
+          <Result
+            style={{ margin: 'auto' }}
+            status={404}
+            title={
+              <>
+                <strong>404</strong>
+                <p>Page Not Found</p>
+              </>
+            }
+            subTitle="The page you are looking for doesn't exists."
+            extra={<Link to={path}>Back to Products</Link>}
+          />
+        )}
       />
     </Switch>
   )

--- a/packages/client/src/pages/PurchasedProductsPage/index.jsx
+++ b/packages/client/src/pages/PurchasedProductsPage/index.jsx
@@ -1,42 +1,48 @@
 import React, { useLayoutEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Table, Empty } from 'antd'
-import axios from 'axios'
 
 import ReviewItem from '@components/ReviewItem/index'
 
-import { USER_REVIEWS_COLUMNS } from '@shared/constants'
 import { getPurchasedProductsAndReviews } from '@redux/user/userThunk'
+
+import { USER_REVIEWS_COLUMNS } from '@shared/constants'
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 
 const PurchasedProductsPage = ({ uid, updateFor, purchasedProducts }) => {
   const dispatch = useDispatch()
   const [loading, setLoading] = useState(false)
   const [errMsg, setErrMsg] = useState('')
+  const { showBoundary } = useErrorBoundary()
 
   useLayoutEffect(() => {
-    const source = axios.CancelToken.source()
+    let response
 
     const getPurchasedProducts = async () => {
       try {
         if (uid && !purchasedProducts) {
           setLoading(true)
-          await dispatch(
+          response = dispatch(
             getPurchasedProductsAndReviews({
               uid,
-              cancelToken: source,
               updateFor,
             })
-          ).unwrap()
+          )
+
+          await response?.unwrap?.()
           setLoading(false)
         }
       } catch (err) {
-        const {
-          data: { message },
-        } = err
+        setLoading(false)
 
-        if (err.status !== 'ABORTED') {
-          setLoading(false)
+        handleAsyncThunkError(err, showBoundary, {
+          showBoundaryOnlyOnServerError: true,
+        })
+
+        if (err.name !== 'AbortError') {
+          const { data: { message } = { message: undefined } } = err
           setErrMsg(message)
         }
       }
@@ -45,9 +51,9 @@ const PurchasedProductsPage = ({ uid, updateFor, purchasedProducts }) => {
     getPurchasedProducts()
 
     return () => {
-      source.cancel('Request Aborted due to component unmount.')
+      response?.abort?.('Request Aborted due to component unmount.')
     }
-  }, [dispatch, uid, updateFor, purchasedProducts])
+  }, [dispatch, uid, updateFor, purchasedProducts, showBoundary])
 
   return (
     <Table

--- a/packages/client/src/pages/ResetPasswordPage/index.jsx
+++ b/packages/client/src/pages/ResetPasswordPage/index.jsx
@@ -1,5 +1,7 @@
-import React, { useState, useCallback } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
+import axios from 'axios'
 import { useParams, Link } from 'react-router-dom'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Card, Alert } from 'antd'
 import { LockOutlined } from '@ant-design/icons'
 import { Formik, Field } from 'formik'
@@ -9,18 +11,28 @@ import InputField from '@components/InputField/index'
 
 import { resetPassword } from '@api/user/auth'
 import { resetPassValidationSchema } from '@validation/user-validation'
+import ErrorHandler from '@utils/ErrorHandler'
 
 import './styles.scss'
 
 const ResetPasswordPage = () => {
   const { resetToken } = useParams()
-  const [serverResponse, setServerResponse] = useState({})
+  const source = axios.CancelToken.source()
+  const { showBoundary } = useErrorBoundary()
+  const [serverResponse, setServerResponse] = useState()
+
+  useEffect(() => {
+    return () => {
+      source.cancel('Request Aborted due to component unmount.')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleSubmit = useCallback(
     async (values, { setFieldError, resetForm }) => {
-      setServerResponse({})
+      setServerResponse()
       try {
-        const response = await resetPassword(values, resetToken)
+        const response = await resetPassword(values, resetToken, source.token)
         const {
           status,
           data: { message },
@@ -28,18 +40,29 @@ const ResetPasswordPage = () => {
 
         setServerResponse({ status, message })
         resetForm()
-      } catch ({ response }) {
-        const {
-          status,
-          statusText,
-          data: { errors, message },
-        } = response
+      } catch (error) {
+        if (!axios.isCancel(error) && error.response) {
+          const {
+            response: {
+              status,
+              statusText,
+              data: { errors, message },
+            },
+          } = error
 
-        if (errors) {
-          Object.keys(errors).forEach(err =>
-            setFieldError(err, errors[err].message)
-          )
-        } else {
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(message, status, statusText)
+            showBoundary(boundaryError)
+            return
+          }
+
+          if (errors) {
+            Object.keys(errors).forEach(err =>
+              setFieldError(err, errors[err].message)
+            )
+            return
+          }
+
           setServerResponse({
             status,
             statusText,
@@ -48,13 +71,13 @@ const ResetPasswordPage = () => {
         }
       }
     },
-    [resetToken]
+    [resetToken, showBoundary, source.token]
   )
 
   return (
     <>
       <div className='ResetpasswordPage'>
-        {Object.keys(serverResponse).length > 0 && (
+        {serverResponse && (
           <Alert
             type={serverResponse.status >= 400 ? 'error' : 'success'}
             message={

--- a/packages/client/src/pages/ResetPasswordPage/index.jsx
+++ b/packages/client/src/pages/ResetPasswordPage/index.jsx
@@ -8,6 +8,7 @@ import { Formik, Field } from 'formik'
 import { Form, SubmitButton } from 'formik-antd'
 
 import InputField from '@components/InputField/index'
+import RouterPrompt from '@components/RouterPrompt/index'
 
 import { resetPassword } from '@api/user/auth'
 import { resetPassValidationSchema } from '@validation/user-validation'
@@ -102,32 +103,35 @@ const ResetPasswordPage = () => {
             onSubmit={handleSubmit}
             validationSchema={resetPassValidationSchema}>
             {({ dirty, isValid }) => (
-              <Form layout='vertical' size='large'>
-                <Field
-                  name='newPassword'
-                  type='password'
-                  prefix={<LockOutlined className='site-form-item-icon' />}
-                  placeholder='New password'
-                  component={InputField}
-                />
-                <Field
-                  name='confirmNewPassword'
-                  type='password'
-                  prefix={<LockOutlined className='site-form-item-icon' />}
-                  placeholder='Confirm new password'
-                  component={InputField}
-                />
-                <Form.Item name='forgotPassword'>
-                  <SubmitButton block disabled={!dirty || !isValid}>
-                    Send request
-                  </SubmitButton>
-                </Form.Item>
-                <Form.Item name='signin' noStyle>
-                  <span className='signin-caption'>
-                    Go back to <Link to='/auth/signin'>Sign In</Link>
-                  </span>
-                </Form.Item>
-              </Form>
+              <>
+                <RouterPrompt when={dirty} />
+                <Form layout='vertical' size='large'>
+                  <Field
+                    name='newPassword'
+                    type='password'
+                    prefix={<LockOutlined className='site-form-item-icon' />}
+                    placeholder='New password'
+                    component={InputField}
+                  />
+                  <Field
+                    name='confirmNewPassword'
+                    type='password'
+                    prefix={<LockOutlined className='site-form-item-icon' />}
+                    placeholder='Confirm new password'
+                    component={InputField}
+                  />
+                  <Form.Item name='forgotPassword'>
+                    <SubmitButton block disabled={!dirty || !isValid}>
+                      Send request
+                    </SubmitButton>
+                  </Form.Item>
+                  <Form.Item name='signin' noStyle>
+                    <span className='signin-caption'>
+                      Go back to <Link to='/auth/signin'>Sign In</Link>
+                    </span>
+                  </Form.Item>
+                </Form>
+              </>
             )}
           </Formik>
         </Card>

--- a/packages/client/src/pages/ResetPasswordPage/styles.scss
+++ b/packages/client/src/pages/ResetPasswordPage/styles.scss
@@ -7,13 +7,16 @@
 
   & div.ant-card.ant-card-bordered {
     width: 400px;
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 15px;
+    overflow: hidden;
+    border-radius: 1rem;
+    border-color: #1b2330;
 
     div.ant-card-head {
       text-align: center;
+      background-color: #1b2330;
 
       & div.ant-card-head-title {
+        color: #fff;
         padding: 1.5rem 0;
         font-size: 1.7rem;
       }

--- a/packages/client/src/pages/SigninPage/index.jsx
+++ b/packages/client/src/pages/SigninPage/index.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useCallback } from 'react'
+import React, { useEffect, useRef, useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Card, Button, Alert } from 'antd'
 import { UserOutlined, LockOutlined } from '@ant-design/icons'
 import { Formik, Field } from 'formik'
@@ -13,6 +14,8 @@ import { ReactComponent as GoogleIcon } from '@assets/Google_logo.svg'
 import { signin } from '@redux/user/userThunk'
 import { selectLoggedInUser } from '@redux/user/userSlice'
 import { create as createNotification } from '@redux/notification/notificationSlice'
+
+import ErrorHandler from '@utils/ErrorHandler'
 import { signinValidationSchema } from '@validation/user-validation'
 
 import './styles.scss'
@@ -20,17 +23,27 @@ import './styles.scss'
 const SigninPage = ({ location }) => {
   const dispatch = useDispatch()
   const loggedInUser = useSelector(selectLoggedInUser)
+  const signinRef = useRef()
+  const { showBoundary } = useErrorBoundary()
   const [validateOnBlur, setValidateOnBlur] = useState(true)
-  const [serverResponse, setServerResponse] = useState({})
+  const [serverResponse, setServerResponse] = useState()
   const [errMsg, setErrMsg] = useState('')
   const [nonExistingUsers, setNonExistingUsers] = useState([])
+
+  useEffect(() => {
+    return () => {
+      signinRef.current?.abort?.('Request Aborted due to component unmount.')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleSubmit = useCallback(
     async (values, { setFieldError }) => {
       setValidateOnBlur(true)
-      setServerResponse({})
+      setServerResponse()
       try {
-        const { message } = await dispatch(signin(values)).unwrap()
+        signinRef.current = dispatch(signin({ userData: values }))
+        const { message } = await signinRef.current?.unwrap?.()
 
         dispatch(
           createNotification({
@@ -41,22 +54,34 @@ const SigninPage = ({ location }) => {
           })
         )
       } catch (error) {
-        const {
-          status,
-          statusText,
-          data: { errors, message },
-        } = error
+        if (!error.name || error.name !== 'AbortError') {
+          const {
+            status,
+            statusText,
+            data: { errors, message } = {
+              errors: undefined,
+              message: undefined,
+            },
+          } = error
 
-        if (errors) {
-          setValidateOnBlur(false)
-          Object.keys(errors).forEach(err => {
-            setFieldError(err, errors[err].message)
-            if (err === 'userNameOrEmail') {
-              setNonExistingUsers(users => [...users, errors[err].value])
-              setErrMsg(errors[err].message)
-            }
-          })
-        } else {
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(message, status, statusText)
+            showBoundary(boundaryError)
+            return
+          }
+
+          if (errors) {
+            setValidateOnBlur(false)
+            Object.keys(errors).forEach(err => {
+              setFieldError(err, errors[err].message)
+              if (err === 'userNameOrEmail') {
+                setNonExistingUsers(users => [...users, errors[err].value])
+                setErrMsg(errors[err].message)
+              }
+            })
+            return
+          }
+
           setServerResponse({
             status,
             statusText,
@@ -65,12 +90,12 @@ const SigninPage = ({ location }) => {
         }
       }
     },
-    [dispatch]
+    [dispatch, showBoundary]
   )
 
   return (
     <div className='SigninPage'>
-      {Object.keys(serverResponse).length > 0 && (
+      {serverResponse && (
         <Alert
           type={serverResponse.status >= 400 ? 'error' : 'success'}
           message={

--- a/packages/client/src/pages/SigninPage/index.jsx
+++ b/packages/client/src/pages/SigninPage/index.jsx
@@ -9,6 +9,7 @@ import { Formik, Field } from 'formik'
 import { Form, SubmitButton } from 'formik-antd'
 
 import InputField from '@components/InputField/index'
+import RouterPrompt from '@components/RouterPrompt/index'
 import { ReactComponent as GoogleIcon } from '@assets/Google_logo.svg'
 
 import { signin } from '@redux/user/userThunk'
@@ -129,65 +130,70 @@ const SigninPage = ({ location }) => {
           validationSchema={signinValidationSchema(nonExistingUsers, errMsg)}
           validateOnBlur={validateOnBlur}>
           {({ dirty, isValid }) => (
-            <Form layout='vertical' size='large'>
-              <Field
-                name='userNameOrEmail'
-                prefix={<UserOutlined className='site-form-item-icon' />}
-                placeholder='Username or Email address'
-                component={InputField}
-              />
-              <Field
-                name='password'
-                type='password'
-                prefix={<LockOutlined className='site-form-item-icon' />}
-                placeholder='Password'
-                component={InputField}
-              />
-              <Form.Item name='forgotPassword'>
-                <Link to='/auth/forgot-password' style={{ float: 'right' }}>
-                  Forgot password?
-                </Link>
-              </Form.Item>
-              <Form.Item name='signin' style={{ marginBottom: 0 }}>
-                <SubmitButton block disabled={!dirty || !isValid}>
-                  Sign in
-                </SubmitButton>
-              </Form.Item>
-              <div
-                className='signin-divider'
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}>
-                <hr />
-                <span>OR</span>
-                <hr />
-              </div>
-              <Form.Item name='signinWithGoogle'>
-                <Button
-                  id='google-signin-btn'
-                  block
-                  type='dashed'
-                  htmlType='button'
-                  icon={<GoogleIcon id='google-icon' />}
-                  onClick={() => {
-                    window.location = `http://localhost:5000/api/users/auth/google${
-                      location.state
-                        ? `?redirect_to=${location.state.from.pathname}`
-                        : ''
-                    }`
+            <>
+              <RouterPrompt when={dirty} />
+              <Form layout='vertical' size='large'>
+                <Field
+                  name='userNameOrEmail'
+                  prefix={<UserOutlined className='site-form-item-icon' />}
+                  placeholder='Username or Email address'
+                  component={InputField}
+                />
+                <Field
+                  name='password'
+                  type='password'
+                  prefix={<LockOutlined className='site-form-item-icon' />}
+                  placeholder='Password'
+                  component={InputField}
+                />
+                <Form.Item name='forgotPassword'>
+                  <Link to='/auth/forgot-password' style={{ float: 'right' }}>
+                    Forgot password?
+                  </Link>
+                </Form.Item>
+                <Form.Item name='signin' style={{ marginBottom: 0 }}>
+                  <SubmitButton block disabled={!dirty || !isValid}>
+                    Sign in
+                  </SubmitButton>
+                </Form.Item>
+                <div
+                  className='signin-divider'
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
                   }}>
-                  Sign in with Google
-                </Button>
-              </Form.Item>
-              <Form.Item name='register' noStyle>
-                <span className='signup-caption'>
-                  New to G-Shock-Watches?
-                  <br /> Go <Link to='/auth/signup'>Register now!</Link>
-                </span>
-              </Form.Item>
-            </Form>
+                  <hr />
+                  <span>OR</span>
+                  <hr />
+                </div>
+                <Form.Item name='signinWithGoogle'>
+                  <Button
+                    id='google-signin-btn'
+                    block
+                    type='dashed'
+                    htmlType='button'
+                    icon={<GoogleIcon id='google-icon' />}
+                    onClick={() => {
+                      window.location = `${
+                        process.env.REACT_APP_API_BASE_URL
+                      }/api/users/auth/google${
+                        location.state
+                          ? `?redirect_to=${location.state.from.pathname}`
+                          : ''
+                      }`
+                    }}>
+                    Sign in with Google
+                  </Button>
+                </Form.Item>
+                <Form.Item name='register' noStyle>
+                  <span className='signup-caption'>
+                    New to G-Shock-Watches?
+                    <br /> Go <Link to='/auth/signup'>Register now!</Link>
+                  </span>
+                </Form.Item>
+              </Form>
+            </>
           )}
         </Formik>
       </Card>

--- a/packages/client/src/pages/SigninPage/styles.scss
+++ b/packages/client/src/pages/SigninPage/styles.scss
@@ -7,13 +7,16 @@
 
   & div.ant-card.ant-card-bordered {
     width: 400px;
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 15px;
+    overflow: hidden;
+    border-radius: 1rem;
+    border-color: #1b2330;
 
     div.ant-card-head {
       text-align: center;
+      background-color: #1b2330;
 
       & div.ant-card-head-title {
+        color: #fff;
         padding: 1.5rem 0;
         font-size: 1.7rem;
       }

--- a/packages/client/src/pages/SignupPage/index.jsx
+++ b/packages/client/src/pages/SignupPage/index.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Card, Alert, message as infoMessage } from 'antd'
 import { UserOutlined, MailOutlined, LockOutlined } from '@ant-design/icons'
 import { Formik, Field } from 'formik'
@@ -12,6 +13,8 @@ import AvatarUpload from '@components/AvatarUpload/index'
 import { signup } from '@redux/user/userThunk'
 import { selectLoggedInUser } from '@redux/user/userSlice'
 import { create as createNotification } from '@redux/notification/notificationSlice'
+
+import ErrorHandler from '@utils/ErrorHandler'
 import { signupValidationSchema } from '@validation/user-validation'
 
 import './styles.scss'
@@ -27,19 +30,28 @@ const InfoMessage = () => {
 const SignupPage = () => {
   const dispatch = useDispatch()
   const loggedInUser = useSelector(selectLoggedInUser)
-
-  const [serverResponse, setServerResponse] = useState({})
+  const signupRef = useRef()
+  const { showBoundary } = useErrorBoundary()
+  const [serverResponse, setServerResponse] = useState()
   const [existingEmails, setExistingEmails] = useState([])
   const [existingUserNames, setExistingUserNames] = useState([])
 
+  useEffect(() => {
+    return () => {
+      signupRef.current?.abort?.('Request Aborted due to component unmount.')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const handleSubmit = useCallback(
     async (values, { setFieldError }) => {
-      setServerResponse({})
+      setServerResponse()
       try {
         const data = new FormData()
         Object.keys(values).forEach(key => data.append(key, values[key]))
 
-        const { message } = await dispatch(signup(data)).unwrap()
+        signupRef.current = dispatch(signup({ userData: data }))
+        const { message } = await signupRef.current?.unwrap?.()
 
         dispatch(
           createNotification({
@@ -50,23 +62,38 @@ const SignupPage = () => {
           })
         )
       } catch (error) {
-        const { errors, message } = error.data
-        const { status, statusText } = error
+        if (!error.name || error.name !== 'AbortError') {
+          const {
+            status,
+            statusText,
+            data: { errors, message } = {
+              errors: undefined,
+              message: undefined,
+            },
+          } = error
 
-        if (errors) {
-          Object.keys(errors).forEach(err => {
-            if (err === 'userName') {
-              setExistingUserNames(userNames => [
-                ...userNames,
-                errors[err].value,
-              ])
-            }
-            if (err === 'email') {
-              setExistingEmails(emails => [...emails, errors[err].value])
-            }
-            setFieldError(err, errors[err].message)
-          })
-        } else {
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(message, status, statusText)
+            showBoundary(boundaryError)
+            return
+          }
+
+          if (errors) {
+            Object.keys(errors).forEach(err => {
+              if (err === 'userName') {
+                setExistingUserNames(userNames => [
+                  ...userNames,
+                  errors[err].value,
+                ])
+              }
+              if (err === 'email') {
+                setExistingEmails(emails => [...emails, errors[err].value])
+              }
+              setFieldError(err, errors[err].message)
+            })
+            return
+          }
+
           setServerResponse({
             status,
             statusText,
@@ -75,7 +102,7 @@ const SignupPage = () => {
         }
       }
     },
-    [dispatch]
+    [dispatch, showBoundary]
   )
 
   useEffect(() => {
@@ -92,7 +119,7 @@ const SignupPage = () => {
 
   return (
     <div className='SignupPage'>
-      {Object.keys(serverResponse).length > 0 && (
+      {serverResponse && (
         <Alert
           type={serverResponse.status >= 400 ? 'error' : 'success'}
           message={

--- a/packages/client/src/pages/SignupPage/index.jsx
+++ b/packages/client/src/pages/SignupPage/index.jsx
@@ -9,6 +9,7 @@ import { Form, SubmitButton } from 'formik-antd'
 
 import InputField from '@components/InputField/index'
 import AvatarUpload from '@components/AvatarUpload/index'
+import RouterPrompt from '@components/RouterPrompt/index'
 
 import { signup } from '@redux/user/userThunk'
 import { selectLoggedInUser } from '@redux/user/userSlice'
@@ -161,47 +162,50 @@ const SignupPage = () => {
             existingEmails
           )}>
           {({ dirty, isValid }) => (
-            <Form layout='vertical' size='large'>
-              <Field name='avatar' component={AvatarUpload} />
-              <Field
-                name='userName'
-                prefix={<UserOutlined className='site-form-item-icon' />}
-                placeholder='Username'
-                component={InputField}
-              />
-              <Field
-                name='email'
-                type='email'
-                prefix={<MailOutlined className='site-form-item-icon' />}
-                placeholder='Email address'
-                component={InputField}
-              />
-              <Field
-                name='password'
-                type='password'
-                prefix={<LockOutlined className='site-form-item-icon' />}
-                placeholder='Password'
-                component={InputField}
-              />
-              <Field
-                name='confirmPassword'
-                type='password'
-                prefix={<LockOutlined className='site-form-item-icon' />}
-                placeholder='Confirm password'
-                component={InputField}
-              />
-              <Form.Item name='signup'>
-                <SubmitButton block disabled={!dirty || !isValid}>
-                  Sign up
-                </SubmitButton>
-              </Form.Item>
-              <Form.Item name='signin' noStyle>
-                <span className='signin-caption'>
-                  Already have an account?
-                  <br /> Go <Link to='/auth/signin'>Sign In now!</Link>
-                </span>
-              </Form.Item>
-            </Form>
+            <>
+              <RouterPrompt when={dirty} />
+              <Form layout='vertical' size='large'>
+                <Field name='avatar' component={AvatarUpload} />
+                <Field
+                  name='userName'
+                  prefix={<UserOutlined className='site-form-item-icon' />}
+                  placeholder='Username'
+                  component={InputField}
+                />
+                <Field
+                  name='email'
+                  type='email'
+                  prefix={<MailOutlined className='site-form-item-icon' />}
+                  placeholder='Email address'
+                  component={InputField}
+                />
+                <Field
+                  name='password'
+                  type='password'
+                  prefix={<LockOutlined className='site-form-item-icon' />}
+                  placeholder='Password'
+                  component={InputField}
+                />
+                <Field
+                  name='confirmPassword'
+                  type='password'
+                  prefix={<LockOutlined className='site-form-item-icon' />}
+                  placeholder='Confirm password'
+                  component={InputField}
+                />
+                <Form.Item name='signup'>
+                  <SubmitButton block disabled={!dirty || !isValid}>
+                    Sign up
+                  </SubmitButton>
+                </Form.Item>
+                <Form.Item name='signin' noStyle>
+                  <span className='signin-caption'>
+                    Already have an account?
+                    <br /> Go <Link to='/auth/signin'>Sign In now!</Link>
+                  </span>
+                </Form.Item>
+              </Form>
+            </>
           )}
         </Formik>
       </Card>

--- a/packages/client/src/pages/SignupPage/styles.scss
+++ b/packages/client/src/pages/SignupPage/styles.scss
@@ -9,8 +9,9 @@
   & div.ant-card.ant-card-bordered {
     width: 400px;
     position: relative;
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 15px;
+    overflow: hidden;
+    border-radius: 1rem;
+    border-color: #1b2330;
 
     div.form-item-upload {
       width: 100%;
@@ -25,8 +26,10 @@
       height: 151px;
       text-align: center;
       margin-bottom: 100px;
+      background-color: #1b2330;
 
       & div.ant-card-head-title {
+        color: #fff;
         padding: 1.5rem 0;
         font-size: 1.7rem;
       }

--- a/packages/client/src/pages/UpdateOrderPage/index.jsx
+++ b/packages/client/src/pages/UpdateOrderPage/index.jsx
@@ -1,8 +1,8 @@
-/* eslint-disable no-unused-vars */
 import React, { useLayoutEffect, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { useParams, generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Spin, Button, Tabs, Table, Collapse } from 'antd'
 import {
   ArrowLeftOutlined,
@@ -19,6 +19,8 @@ import {
   ORDER_PRODUCTS_COLUMNS,
 } from '@shared/constants'
 
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
+
 import './styles.scss'
 
 const { TabPane } = Tabs
@@ -27,18 +29,34 @@ const { Panel } = Collapse
 const UpdateOrderPage = ({ history, match }) => {
   const { oid, activeTab } = useParams()
   const dispatch = useDispatch()
-  const { loading, updating, data: order } = useSelector(
-    selectOrdersByType('preview')
-  )
+  const { loading, data: order } = useSelector(selectOrdersByType('preview'))
   const [activeTabKey, setActiveTabKey] = useState(activeTab)
+  const { showBoundary } = useErrorBoundary()
 
   useLayoutEffect(() => {
-    dispatch(getOrderById(oid))
+    let response
+
+    const fetchOrderById = async () => {
+      try {
+        response = dispatch(getOrderById(oid))
+        await response?.unwrap?.()
+      } catch (err) {
+        handleAsyncThunkError(err, showBoundary, {
+          redirect: {
+            to: '/admin/e-commerce/orders',
+            text: 'Back to Orders',
+          },
+        })
+      }
+    }
+
+    fetchOrderById()
 
     return () => {
       dispatch(clearOrderPreview())
+      response?.abort?.('Request Aborted due to component unmount.')
     }
-  }, [dispatch, oid])
+  }, [dispatch, oid, showBoundary])
 
   useEffect(() => {
     if (activeTab) {

--- a/packages/client/src/pages/UpdateOrderPage/index.jsx
+++ b/packages/client/src/pages/UpdateOrderPage/index.jsx
@@ -1,6 +1,6 @@
 import React, { useLayoutEffect, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import { useParams, generatePath } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { useErrorBoundary } from 'react-error-boundary'
 import { Spin, Button, Tabs, Table, Collapse } from 'antd'
@@ -27,10 +27,9 @@ const { TabPane } = Tabs
 const { Panel } = Collapse
 
 const UpdateOrderPage = ({ history, match }) => {
-  const { oid, activeTab } = useParams()
+  const { oid, activeTab } = match.params
   const dispatch = useDispatch()
   const { loading, data: order } = useSelector(selectOrdersByType('preview'))
-  const [activeTabKey, setActiveTabKey] = useState(activeTab)
   const { showBoundary } = useErrorBoundary()
 
   useLayoutEffect(() => {
@@ -58,14 +57,6 @@ const UpdateOrderPage = ({ history, match }) => {
     }
   }, [dispatch, oid, showBoundary])
 
-  useEffect(() => {
-    if (activeTab) {
-      setActiveTabKey(activeTab)
-    } else {
-      setActiveTabKey('info')
-    }
-  }, [activeTab])
-
   return (
     <div className='UpdateOrderPageWrapper'>
       {loading ? (
@@ -88,7 +79,7 @@ const UpdateOrderPage = ({ history, match }) => {
           </div>
           <Tabs
             defaultActiveKey='info'
-            activeKey={activeTabKey}
+            activeKey={activeTab || 'info'}
             onTabClick={activeKey => {
               const generatedPath = generatePath(match.path, {
                 oid,

--- a/packages/client/src/pages/UpdateProductPage/index.jsx
+++ b/packages/client/src/pages/UpdateProductPage/index.jsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react'
 import axios from 'axios'
 import PropTypes from 'prop-types'
-import { useParams, generatePath } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { useErrorBoundary } from 'react-error-boundary'
 import { Button, Tabs, Row, Col, Spin, message as updatingMessage } from 'antd'
@@ -62,8 +62,7 @@ const UpdatingMessage = () => {
 }
 
 const UpdateProductPage = ({ history, match }) => {
-  const { pid, activeTab } = useParams()
-  const [activeTabKey, setActiveTabKey] = useState(activeTab)
+  const { pid, activeTab } = match.params
   const [shouldFormReset, setShouldFormReset] = useState(true)
   const [defaultFileList, setDefaultFileList] = useState([])
   const [removedFileList, setRemovedFileList] = useState([])
@@ -130,14 +129,6 @@ const UpdateProductPage = ({ history, match }) => {
   }, [dispatch, pid, showBoundary])
 
   useEffect(() => {
-    if (activeTab) {
-      setActiveTabKey(activeTab)
-    } else {
-      setActiveTabKey('info')
-    }
-  }, [activeTab])
-
-  useEffect(() => {
     return () => {
       updateProductRef.current?.abort?.(
         'Request Aborted due to component unmount.'
@@ -156,16 +147,18 @@ const UpdateProductPage = ({ history, match }) => {
           name: product.previewImg.split('/').pop(),
           status: 'done',
           path: product.previewImg,
-          url: `http://localhost:5000${product.previewImg}`,
-          thumbUrl: `http://localhost:5000${product.previewImg}`,
+          url: `${process.env.REACT_APP_API_BASE_URL + product.previewImg}`,
+          thumbUrl: `${
+            process.env.REACT_APP_API_BASE_URL + product.previewImg
+          }`,
         },
         ...product.images?.map((image, idx) => ({
           uid: `${idx + 1}`,
           name: image.split('/').pop(),
           status: 'done',
           path: image,
-          url: `http://localhost:5000${image}`,
-          thumbUrl: `http://localhost:5000${image}`,
+          url: `${process.env.REACT_APP_API_BASE_URL + image}`,
+          thumbUrl: `${process.env.REACT_APP_API_BASE_URL + image}`,
         })),
       ])
 
@@ -226,7 +219,7 @@ const UpdateProductPage = ({ history, match }) => {
         )
 
         setShouldFormReset(true)
-        setActiveTabKey('info')
+        history.replace(generatePath(match.path, { pid }))
       } catch (error) {
         if (!error.name || error.name !== 'AbortError') {
           const {
@@ -277,7 +270,7 @@ const UpdateProductPage = ({ history, match }) => {
         }
       }
     },
-    [dispatch, pid, removedFileList, showBoundary]
+    [dispatch, pid, removedFileList, history, match.path, showBoundary]
   )
 
   return (
@@ -440,7 +433,7 @@ const UpdateProductPage = ({ history, match }) => {
                 </div>
                 <Tabs
                   defaultActiveKey='info'
-                  activeKey={activeTabKey}
+                  activeKey={activeTab || 'info'}
                   onTabClick={activeKey => {
                     const generatedPath = generatePath(match.path, {
                       pid,

--- a/packages/client/src/pages/UpdateProductPage/index.jsx
+++ b/packages/client/src/pages/UpdateProductPage/index.jsx
@@ -1,8 +1,15 @@
-/* eslint-disable no-unused-vars */
-import React, { useLayoutEffect, useEffect, useCallback, useState } from 'react'
+import React, {
+  useLayoutEffect,
+  useEffect,
+  useCallback,
+  useState,
+  useRef,
+} from 'react'
+import axios from 'axios'
 import PropTypes from 'prop-types'
 import { useParams, generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Button, Tabs, Row, Col, Spin, message as updatingMessage } from 'antd'
 import {
   ArrowLeftOutlined,
@@ -39,6 +46,9 @@ import {
   PRODUCT_MAIN_FEATURES_OPTIONS,
 } from '@shared/constants'
 
+import ErrorHandler from '@utils/ErrorHandler'
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
+
 import './styles.scss'
 
 const { TabPane } = Tabs
@@ -57,21 +67,67 @@ const UpdateProductPage = ({ history, match }) => {
   const [shouldFormReset, setShouldFormReset] = useState(true)
   const [defaultFileList, setDefaultFileList] = useState([])
   const [removedFileList, setRemovedFileList] = useState([])
+  const [existingModels, setExistingModels] = useState([])
   const dispatch = useDispatch()
   const collections = useSelector(selectCollections)
   const { loading, updating, data: product } = useSelector(
     selectProductsByType('preview')
   )
+  const source = axios.CancelToken.source()
+  const updateProductRef = useRef()
+  const { showBoundary } = useErrorBoundary()
 
   useLayoutEffect(() => {
-    dispatch(getCollections())
-    dispatch(getProductById(pid))
+    let response
+
+    const fetchCollections = async () => {
+      try {
+        response = dispatch(getCollections())
+        await response?.unwrap?.()
+      } catch (err) {
+        handleAsyncThunkError(err, showBoundary, {
+          redirect: {
+            to: '/admin/e-commerce/products',
+            text: 'Back to Products',
+          },
+        })
+      }
+    }
+
+    fetchCollections()
+
+    return () => {
+      response?.abort?.('Request Aborted due to component unmount.')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, showBoundary])
+
+  useLayoutEffect(() => {
+    let response
+
+    const fetchProductById = async () => {
+      try {
+        response = dispatch(getProductById(pid))
+        await response?.unwrap?.()
+      } catch (err) {
+        handleAsyncThunkError(err, showBoundary, {
+          redirect: {
+            to: '/admin/e-commerce/products',
+            text: 'Back to Products',
+          },
+        })
+      }
+    }
+
+    fetchProductById()
 
     return () => {
       setDefaultFileList([])
       dispatch(clearProductPreview())
+      response?.abort?.('Request Aborted due to component unmount.')
     }
-  }, [dispatch, pid])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, pid, showBoundary])
 
   useEffect(() => {
     if (activeTab) {
@@ -80,6 +136,17 @@ const UpdateProductPage = ({ history, match }) => {
       setActiveTabKey('info')
     }
   }, [activeTab])
+
+  useEffect(() => {
+    return () => {
+      updateProductRef.current?.abort?.(
+        'Request Aborted due to component unmount.'
+      )
+      source.cancel('Request Aborted due to component unmount.')
+      updatingMessage.destroy('updating')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     if (product && shouldFormReset) {
@@ -121,20 +188,20 @@ const UpdateProductPage = ({ history, match }) => {
 
         Object.entries(values).forEach(([key, value]) => {
           if (Array.isArray(value)) {
-            value.forEach(val => {
+            return value.forEach(val => {
               if (key === 'images' && val.path) {
-                data.append(`${key}[]`, val.path)
-              } else {
-                data.append(`${key}[]`, val)
+                return data.append(`${key}[]`, val.path)
               }
-            })
-          } else {
-            if (key === 'previewImg' && value.path) {
-              data.append(key, value.path)
-            }
 
-            data.append(key, value)
+              return data.append(`${key}[]`, val)
+            })
           }
+
+          if (key === 'previewImg' && value.path) {
+            return data.append(key, value.path)
+          }
+
+          return data.append(key, value)
         })
 
         if (removedFileList.length > 0) {
@@ -143,9 +210,11 @@ const UpdateProductPage = ({ history, match }) => {
           )
         }
 
-        const { message } = await dispatch(
+        updateProductRef.current = dispatch(
           updateProduct({ pid, updatedData: data })
-        ).unwrap()
+        )
+
+        const { message } = await updateProductRef.current?.unwrap?.()
 
         dispatch(
           createNotification({
@@ -159,31 +228,56 @@ const UpdateProductPage = ({ history, match }) => {
         setShouldFormReset(true)
         setActiveTabKey('info')
       } catch (error) {
-        const {
-          status,
-          statusText,
-          data: { errors, message },
-        } = error
+        if (!error.name || error.name !== 'AbortError') {
+          const {
+            status,
+            statusText,
+            data: { errors, message } = {
+              errors: undefined,
+              message: undefined,
+            },
+          } = error
 
-        dispatch(
-          createNotification({
-            id: 'updateProductError',
-            type: 'error',
-            title: `Error, ${statusText}`,
-            description:
-              message ||
-              'Something went wrong while updating a product, please try again later.',
-          })
-        )
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(
+              message,
+              status,
+              statusText,
+              {
+                redirect: {
+                  to: '/admin/e-commerce/products',
+                  text: 'Back to Products',
+                },
+              }
+            )
 
-        if (errors) {
-          Object.keys(errors).forEach(err => {
-            setFieldError(err, errors[err].message)
-          })
+            showBoundary(boundaryError)
+            return
+          }
+
+          dispatch(
+            createNotification({
+              id: 'updateProductError',
+              type: 'error',
+              title: `Error, ${statusText}`,
+              description:
+                message ||
+                'Something went wrong while updating a product, please try again later.',
+            })
+          )
+
+          if (errors) {
+            Object.keys(errors).forEach(err => {
+              if (err === 'model') {
+                setExistingModels(exModels => [...exModels, errors[err].value])
+              }
+              setFieldError(err, errors[err].message)
+            })
+          }
         }
       }
     },
-    [dispatch, pid, removedFileList]
+    [dispatch, pid, removedFileList, showBoundary]
   )
 
   return (
@@ -231,10 +325,9 @@ const UpdateProductPage = ({ history, match }) => {
             specifications: product?.specifications?.join('\n'),
           }}
           onSubmit={handleSubmit}
-          validationSchema={productValidationSchema}>
+          validationSchema={productValidationSchema(existingModels)}>
           {({
             dirty,
-            errors,
             isValid,
             handleSubmit: submitForm,
             setFieldValue,
@@ -315,7 +408,7 @@ const UpdateProductPage = ({ history, match }) => {
                             try {
                               const {
                                 data: { message },
-                              } = await deleteProduct(pid)
+                              } = await deleteProduct(pid, source.token)
 
                               dispatch(
                                 createNotification({
@@ -350,7 +443,7 @@ const UpdateProductPage = ({ history, match }) => {
                   activeKey={activeTabKey}
                   onTabClick={activeKey => {
                     const generatedPath = generatePath(match.path, {
-                      pid: product.id,
+                      pid,
                       activeTab: activeKey,
                     })
 
@@ -361,6 +454,7 @@ const UpdateProductPage = ({ history, match }) => {
                       <Row gutter={[16, 8]}>
                         <Col span={8}>
                           <FastField
+                            fast
                             required
                             size='large'
                             name='name'
@@ -370,6 +464,7 @@ const UpdateProductPage = ({ history, match }) => {
                         </Col>
                         <Col span={8}>
                           <FastField
+                            fast
                             required
                             size='large'
                             name='model'
@@ -379,6 +474,7 @@ const UpdateProductPage = ({ history, match }) => {
                         </Col>
                         <Col span={8}>
                           <FastField
+                            fast
                             required
                             size='large'
                             name='collectionName'
@@ -419,6 +515,7 @@ const UpdateProductPage = ({ history, match }) => {
                       <Row gutter={[16, 8]}>
                         <Col span={4}>
                           <FastField
+                            fast
                             required
                             size='large'
                             name='color'
@@ -432,6 +529,7 @@ const UpdateProductPage = ({ history, match }) => {
                         </Col>
                         <Col span={8}>
                           <FastField
+                            fast
                             required
                             size='large'
                             style={{ width: '100%' }}
@@ -449,6 +547,7 @@ const UpdateProductPage = ({ history, match }) => {
                         </Col>
                         <Col span={4}>
                           <FastField
+                            fast
                             required
                             size='large'
                             style={{ width: '100%' }}
@@ -468,6 +567,7 @@ const UpdateProductPage = ({ history, match }) => {
                         </Col>
                         <Col span={8}>
                           <FastField
+                            fast
                             required
                             size='large'
                             style={{ width: '100%' }}
@@ -487,6 +587,7 @@ const UpdateProductPage = ({ history, match }) => {
                       </Row>
                       <Col span={24}>
                         <FastField
+                          fast
                           required
                           rows={6}
                           size='large'
@@ -501,6 +602,7 @@ const UpdateProductPage = ({ history, match }) => {
                   <TabPane key='images' tab='Product Images'>
                     <Form name='product-images'>
                       <FastField
+                        fast
                         name='images'
                         component={DragImagesUpload}
                         defaultFileList={defaultFileList}
@@ -513,6 +615,7 @@ const UpdateProductPage = ({ history, match }) => {
                     <Form name='product-details' layout='vertical'>
                       <Col span={24}>
                         <FastField
+                          fast
                           required
                           showArrow
                           mode='tags'
@@ -527,6 +630,7 @@ const UpdateProductPage = ({ history, match }) => {
                       </Col>
                       <Col span={24}>
                         <FastField
+                          fast
                           required
                           showArrow
                           mode='tags'
@@ -541,6 +645,7 @@ const UpdateProductPage = ({ history, match }) => {
                       </Col>
                       <Col span={24}>
                         <FastField
+                          fast
                           required
                           showArrow
                           mode='tags'
@@ -557,6 +662,7 @@ const UpdateProductPage = ({ history, match }) => {
                       </Col>
                       <Col span={24}>
                         <FastField
+                          fast
                           required
                           rows={6}
                           size='large'

--- a/packages/client/src/pages/UpdateUserPage/index.jsx
+++ b/packages/client/src/pages/UpdateUserPage/index.jsx
@@ -10,7 +10,7 @@ import React, {
 } from 'react'
 import axios from 'axios'
 import PropTypes from 'prop-types'
-import { useParams, generatePath } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { useErrorBoundary } from 'react-error-boundary'
 import {
@@ -63,8 +63,7 @@ const UpdatingMessage = () => {
 }
 
 const UpdateUserPage = ({ history, match }) => {
-  const { uid, activeTab } = useParams()
-  const [activeTabKey, setActiveTabKey] = useState(activeTab)
+  const { uid, activeTab } = match.params
   const [defaultFileList, setDefaultFileList] = useState([])
   const [shouldFormReset, setShouldFormReset] = useState(true)
   const [existingUserNames, setExistingUserNames] = useState([])
@@ -112,14 +111,6 @@ const UpdateUserPage = ({ history, match }) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
-  useEffect(() => {
-    if (activeTab) {
-      setActiveTabKey(activeTab)
-    } else {
-      setActiveTabKey('info')
-    }
-  }, [activeTab])
 
   useEffect(() => {
     if (user && shouldFormReset) {
@@ -187,7 +178,7 @@ const UpdateUserPage = ({ history, match }) => {
         )
 
         setShouldFormReset(true)
-        setActiveTabKey('info')
+        history.replace(generatePath(match.path, { uid }))
       } catch (error) {
         if (!error.name || error.name !== 'AbortError') {
           const {
@@ -241,7 +232,7 @@ const UpdateUserPage = ({ history, match }) => {
         }
       }
     },
-    [dispatch, uid, showBoundary]
+    [dispatch, uid, history, match.path, showBoundary]
   )
 
   return (
@@ -372,7 +363,7 @@ const UpdateUserPage = ({ history, match }) => {
                 <Tabs
                   style={{ flexGrow: 1 }}
                   defaultActiveKey='info'
-                  activeKey={activeTabKey}
+                  activeKey={activeTab || 'info'}
                   onTabClick={activeKey => {
                     const generatedPath = generatePath(match.path, {
                       uid,

--- a/packages/client/src/pages/UpdateUserPage/index.jsx
+++ b/packages/client/src/pages/UpdateUserPage/index.jsx
@@ -4,12 +4,15 @@ import React, {
   useLayoutEffect,
   useEffect,
   useState,
+  useRef,
   useCallback,
   Suspense,
 } from 'react'
+import axios from 'axios'
 import PropTypes from 'prop-types'
 import { useParams, generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import {
   Row,
   Col,
@@ -40,6 +43,9 @@ import { create as createNotification } from '@redux/notification/notificationSl
 import { deleteUser } from '@api/user/index'
 import { updateUserValidationSchema } from '@validation/user-validation'
 
+import ErrorHandler from '@utils/ErrorHandler'
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
+
 import './styles.scss'
 
 const PurchasedProductsPage = lazy(() =>
@@ -65,13 +71,44 @@ const UpdateUserPage = ({ history, match }) => {
   const [existingEmails, setExistingEmails] = useState([])
   const dispatch = useDispatch()
   const { loading, updating, info: user } = useSelector(selectUserPreview)
+  const updateUserRef = useRef()
+  const source = axios.CancelToken.source()
+  const { showBoundary } = useErrorBoundary()
 
   useLayoutEffect(() => {
-    dispatch(getUserById(uid))
+    let response
+
+    const fetchUserById = async () => {
+      try {
+        response = dispatch(getUserById(uid))
+        await response?.unwrap?.()
+      } catch (err) {
+        handleAsyncThunkError(err, showBoundary, {
+          redirect: {
+            to: '/admin/users',
+            text: 'Back to Users',
+          },
+        })
+      }
+    }
+
+    fetchUserById()
 
     return () => {
       setDefaultFileList([])
       dispatch(clearUserPreview())
+      response?.abort?.('Request Aborted due to component unmount.')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, showBoundary])
+
+  useEffect(() => {
+    return () => {
+      updateUserRef.current?.abort?.(
+        'Request Aborted due to component unmount.'
+      )
+      source.cancel('Request Aborted due to component unmount.')
+      updatingMessage.destroy('updatingUserAcc')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -94,7 +131,7 @@ const UpdateUserPage = ({ history, match }) => {
             path: user.avatarUrl,
             thumbUrl:
               (user.avatarUrl &&
-                `${process.env.REACT_APP_API_BASE_URL}${user.avatarUrl}`) ||
+                `${process.env.REACT_APP_API_BASE_URL + user.avatarUrl}`) ||
               user.cloudinaryUrl ||
               user.accounts[0]?.photos[0]?.value,
           },
@@ -130,9 +167,15 @@ const UpdateUserPage = ({ history, match }) => {
           }
         })
 
-        const { message } = await dispatch(
-          updateUser({ uid, updatedData, updateFor: 'preview' })
-        ).unwrap()
+        updateUserRef.current = dispatch(
+          updateUser({
+            uid,
+            updatedData,
+            updateFor: 'preview',
+          })
+        )
+
+        const { message } = await updateUserRef.current?.unwrap?.()
 
         dispatch(
           createNotification({
@@ -146,41 +189,59 @@ const UpdateUserPage = ({ history, match }) => {
         setShouldFormReset(true)
         setActiveTabKey('info')
       } catch (error) {
-        const {
-          status,
-          statusText,
-          data: { errors, message },
-        } = error
+        if (!error.name || error.name !== 'AbortError') {
+          const {
+            status,
+            statusText,
+            data: { errors, message },
+          } = error
 
-        dispatch(
-          createNotification({
-            id: 'updateUserError',
-            type: 'error',
-            title: `Error, ${statusText}`,
-            description:
-              message ||
-              'Something went wrong while updating a user account, please try again later.',
-          })
-        )
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(
+              message,
+              status,
+              statusText,
+              {
+                redirect: {
+                  to: '/admin/users',
+                  text: 'Back to Users',
+                },
+              }
+            )
 
-        if (errors) {
-          Object.keys(errors).forEach(err => {
-            if (err === 'userName') {
-              setExistingUserNames(userNames => [
-                ...userNames,
-                errors[err].value,
-              ])
-            }
+            showBoundary(boundaryError)
+            return
+          }
 
-            if (err === 'email') {
-              setExistingEmails(emails => [...emails, errors[err].value])
-            }
-            setFieldError(err, errors[err].message)
-          })
+          dispatch(
+            createNotification({
+              id: 'updateUserError',
+              type: 'error',
+              title: `Error, ${statusText}`,
+              description:
+                message ||
+                'Something went wrong while updating a user account, please try again later.',
+            })
+          )
+
+          if (errors) {
+            Object.keys(errors).forEach(err => {
+              if (err === 'userName') {
+                setExistingUserNames(userNames => [
+                  ...userNames,
+                  errors[err].value,
+                ])
+              }
+              if (err === 'email') {
+                setExistingEmails(emails => [...emails, errors[err].value])
+              }
+              setFieldError(err, errors[err].message)
+            })
+          }
         }
       }
     },
-    [dispatch, uid]
+    [dispatch, uid, showBoundary]
   )
 
   return (
@@ -278,7 +339,7 @@ const UpdateUserPage = ({ history, match }) => {
                             try {
                               const {
                                 data: { message },
-                              } = await deleteUser(uid)
+                              } = await deleteUser(uid, source.token)
 
                               dispatch(
                                 createNotification({
@@ -393,7 +454,7 @@ const UpdateUserPage = ({ history, match }) => {
                           <Spin size='large' />
                         </div>
                       }>
-                      <UserOrdersPage uid={user?.id} />
+                      <UserOrdersPage uid={user?.id} updateFor='preview' />
                     </Suspense>
                   </TabPane>
                 </Tabs>

--- a/packages/client/src/pages/UserOrdersPage/index.jsx
+++ b/packages/client/src/pages/UserOrdersPage/index.jsx
@@ -1,36 +1,40 @@
 import React, { useEffect, useState } from 'react'
-import axios from 'axios'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import { Table, Empty } from 'antd'
 
 import { getUserOrders } from '@redux/user/userThunk'
+
 import { ORDERS_COLUMNS } from '@shared/constants'
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
 
 const UserOrdersPage = ({ uid, updateFor }) => {
   const dispatch = useDispatch()
   const [orders, setOrders] = useState([])
   const [isLoading, setIsLoading] = useState(false)
   const [errMsg, setErrMsg] = useState('')
+  const { showBoundary } = useErrorBoundary()
 
   useEffect(() => {
-    const source = axios.CancelToken.source()
+    let response
 
     const getOrdersByUserId = async () => {
       try {
         setIsLoading(true)
-        const { orders: userOrders } = await dispatch(
-          getUserOrders({ uid, cancelToken: source, updateFor })
-        ).unwrap()
+        response = dispatch(getUserOrders({ uid, updateFor }))
+        const { orders: userOrders } = await response?.unwrap?.()
         setOrders(userOrders)
         setIsLoading(false)
       } catch (err) {
-        const {
-          data: { message },
-        } = err
+        setIsLoading(false)
 
-        if (err.status !== 'ABORTED') {
-          setIsLoading(false)
+        handleAsyncThunkError(err, showBoundary, {
+          showBoundaryOnlyOnServerError: true,
+        })
+
+        if (err.name !== 'AbortError') {
+          const { data: { message } = { message: undefined } } = err
           setErrMsg(message)
         }
       }
@@ -39,9 +43,9 @@ const UserOrdersPage = ({ uid, updateFor }) => {
     getOrdersByUserId()
 
     return () => {
-      source.cancel('Request Aborted due to component unmount.')
+      response?.abort?.('Request Aborted due to component unmount.')
     }
-  }, [dispatch, uid, updateFor])
+  }, [dispatch, uid, updateFor, showBoundary])
 
   return (
     <div className='UserOurdersPage'>

--- a/packages/client/src/pages/UserProfilePage/index.jsx
+++ b/packages/client/src/pages/UserProfilePage/index.jsx
@@ -1,8 +1,15 @@
-/* eslint-disable no-unused-vars */
-import React, { lazy, useEffect, useState, useCallback, Suspense } from 'react'
+import React, {
+  lazy,
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+  Suspense,
+} from 'react'
 import PropTypes from 'prop-types'
 import { useParams, generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
+import { useErrorBoundary } from 'react-error-boundary'
 import {
   Row,
   Col,
@@ -32,6 +39,9 @@ import { create as createNotification } from '@redux/notification/notificationSl
 
 import { updateUserValidationSchema } from '@validation/user-validation'
 
+import ErrorHandler from '@utils/ErrorHandler'
+import { handleAsyncThunkError } from '@utils/asyncThunkErrorHandler'
+
 import '../UpdateUserPage/styles.scss'
 
 const PurchasedProductsPage = lazy(() =>
@@ -55,8 +65,23 @@ const UserProfilePage = ({ history, match }) => {
   const [shouldFormReset, setShouldFormReset] = useState(true)
   const [existingUserNames, setExistingUserNames] = useState([])
   const [existingEmails, setExistingEmails] = useState([])
+  const updateUserRef = useRef()
+  const deleteUserRef = useRef()
   const dispatch = useDispatch()
   const { loading, updating, info: user } = useSelector(selectLoggedInUser)
+  const { showBoundary } = useErrorBoundary()
+
+  useEffect(() => {
+    return () => {
+      updateUserRef.current?.abort?.(
+        'Request Aborted due to component unmount.'
+      )
+      deleteUserRef.current?.abort?.(
+        'Request Aborted due to component unmount.'
+      )
+      updatingMessage.destroy('updating')
+    }
+  }, [])
 
   useEffect(() => {
     if (activeTab) {
@@ -76,7 +101,7 @@ const UserProfilePage = ({ history, match }) => {
             path: user.avatarUrl,
             thumbUrl:
               (user.avatarUrl &&
-                `${process.env.REACT_APP_API_BASE_URL}${user.avatarUrl}`) ||
+                `${process.env.REACT_APP_API_BASE_URL + user.avatarUrl}`) ||
               user.cloudinaryUrl ||
               user.photo,
           },
@@ -112,13 +137,15 @@ const UserProfilePage = ({ history, match }) => {
           }
         })
 
-        const { status, statusText, message } = await dispatch(
+        updateUserRef.current = dispatch(
           updateUser({
             uid: user.id,
             updatedData: data,
             updateFor: 'loggedInUser',
           })
-        ).unwrap()
+        )
+
+        await updateUserRef.current?.unwrap?.()
 
         dispatch(
           createNotification({
@@ -132,42 +159,62 @@ const UserProfilePage = ({ history, match }) => {
         setShouldFormReset(true)
         setActiveTabKey('settings')
       } catch (error) {
-        const {
-          status,
-          statusText,
-          data: { errors, message },
-        } = error
+        if (!error.name || error.name !== 'AbortError') {
+          const {
+            status,
+            statusText,
+            data: { errors, message } = {
+              errors: undefined,
+              message: undefined,
+            },
+          } = error
 
-        dispatch(
-          createNotification({
-            id: 'updateUserError',
-            type: 'error',
-            title: `Error, ${statusText}`,
-            description:
-              message ||
-              'Something went wrong while updating a user account, please try again later.',
-          })
-        )
+          if (status === 500) {
+            const boundaryError = new ErrorHandler(
+              message,
+              status,
+              statusText,
+              {
+                redirect: {
+                  to: user?.isAdmin ? '/admin/users' : '/',
+                  text: `Back to ${user?.isAdmin ? 'Users' : 'Home'}`,
+                },
+              }
+            )
 
-        if (errors) {
-          Object.keys(errors).forEach(err => {
-            if (err === 'userName') {
-              setExistingUserNames(userNames => [
-                ...userNames,
-                errors[err].value,
-              ])
-            }
+            showBoundary(boundaryError)
+            return
+          }
 
-            if (err === 'email') {
-              setExistingEmails(emails => [...emails, errors[err].value])
-            }
+          dispatch(
+            createNotification({
+              id: 'updateUserError',
+              type: 'error',
+              title: `Error, ${statusText}`,
+              description:
+                message ||
+                'Something went wrong while updating a user account, please try again later.',
+            })
+          )
 
-            setFieldError(err, errors[err].message)
-          })
+          if (errors) {
+            Object.keys(errors).forEach(err => {
+              if (err === 'userName') {
+                setExistingUserNames(userNames => [
+                  ...userNames,
+                  errors[err].value,
+                ])
+              }
+              if (err === 'email') {
+                setExistingEmails(emails => [...emails, errors[err].value])
+              }
+              setFieldError(err, errors[err].message)
+            })
+          }
         }
       }
     },
-    [dispatch, user.id]
+    [dispatch, user.id, user.isAdmin, showBoundary]
   )
 
   return (
@@ -264,9 +311,13 @@ const UserProfilePage = ({ history, match }) => {
                             'Are you sure that you want to delete your account?',
                           onOk: async () => {
                             try {
-                              const { message } = await dispatch(
+                              deleteUserRef.current = dispatch(
                                 deleteUser(user.id)
-                              ).unwrap()
+                              )
+
+                              const {
+                                message,
+                              } = await deleteUserRef.current?.unwrap?.()
 
                               dispatch(
                                 createNotification({
@@ -278,7 +329,16 @@ const UserProfilePage = ({ history, match }) => {
                               )
 
                               history.push('/')
-                            } catch (error) {
+                            } catch (err) {
+                              handleAsyncThunkError(err, showBoundary, {
+                                redirect: {
+                                  to: user?.isAdmin ? '/admin/users' : '/',
+                                  text: `Back to ${
+                                    user?.isAdmin ? 'Users' : 'Home'
+                                  }`,
+                                },
+                              })
+
                               dispatch(
                                 createNotification({
                                   id: 'deleteUserError',

--- a/packages/client/src/pages/UserProfilePage/index.jsx
+++ b/packages/client/src/pages/UserProfilePage/index.jsx
@@ -7,7 +7,7 @@ import React, {
   Suspense,
 } from 'react'
 import PropTypes from 'prop-types'
-import { useParams, generatePath } from 'react-router-dom'
+import { generatePath } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { useErrorBoundary } from 'react-error-boundary'
 import {
@@ -59,8 +59,7 @@ const UpdatingMessage = () => {
 }
 
 const UserProfilePage = ({ history, match }) => {
-  const { activeTab } = useParams()
-  const [activeTabKey, setActiveTabKey] = useState(activeTab)
+  const { activeTab } = match.params
   const [defaultFileList, setDefaultFileList] = useState([])
   const [shouldFormReset, setShouldFormReset] = useState(true)
   const [existingUserNames, setExistingUserNames] = useState([])
@@ -82,14 +81,6 @@ const UserProfilePage = ({ history, match }) => {
       updatingMessage.destroy('updating')
     }
   }, [])
-
-  useEffect(() => {
-    if (activeTab) {
-      setActiveTabKey(activeTab)
-    } else {
-      setActiveTabKey('settings')
-    }
-  }, [activeTab])
 
   useEffect(() => {
     if (user && shouldFormReset) {
@@ -157,7 +148,7 @@ const UserProfilePage = ({ history, match }) => {
         )
 
         setShouldFormReset(true)
-        setActiveTabKey('settings')
+        history.replace(generatePath(match.path, { uid: user.id }))
       } catch (error) {
         if (!error.name || error.name !== 'AbortError') {
           const {
@@ -214,7 +205,7 @@ const UserProfilePage = ({ history, match }) => {
         }
       }
     },
-    [dispatch, user.id, user.isAdmin, showBoundary]
+    [dispatch, user.id, user.isAdmin, history, match.path, showBoundary]
   )
 
   return (
@@ -251,17 +242,18 @@ const UserProfilePage = ({ history, match }) => {
             <>
               <RouterPrompt when={dirty} />
               <div className='UpdateUserPage'>
-                <div className='caption-background' />
                 <div className='caption'>
                   <div className='user-preview-wrapper'>
-                    <Button
-                      type='link'
-                      style={{ padding: 0 }}
-                      className='user-back-arrow'
-                      icon={<ArrowLeftOutlined />}
-                      onClick={() => history.push('/admin/users')}>
-                      Users
-                    </Button>
+                    {user?.isAdmin && (
+                      <Button
+                        type='link'
+                        style={{ padding: 0 }}
+                        className='user-back-arrow'
+                        icon={<ArrowLeftOutlined />}
+                        onClick={() => history.push('/admin/users')}>
+                        Users
+                      </Button>
+                    )}
                     <div className='new-user-preview'>
                       <Form name='user-avatar' layout='vertical'>
                         <Field
@@ -358,8 +350,8 @@ const UserProfilePage = ({ history, match }) => {
                 </div>
                 <Tabs
                   style={{ flexGrow: 1 }}
-                  defaultActiveKey='settings'
-                  activeKey={activeTabKey}
+                  defaultActiveKey='info'
+                  activeKey={activeTab || 'info'}
                   onTabClick={activeKey => {
                     const generatedPath = generatePath(match.path, {
                       uid: user.id,
@@ -368,7 +360,7 @@ const UserProfilePage = ({ history, match }) => {
 
                     history.replace(generatedPath)
                   }}>
-                  <TabPane key='settings' tab='Basic User Info'>
+                  <TabPane key='info' tab='Basic User Info'>
                     <Form name='user-info' layout='vertical'>
                       <Row gutter={[16, 8]}>
                         <Col span={8}>

--- a/packages/client/src/pages/UsersPage/index.jsx
+++ b/packages/client/src/pages/UsersPage/index.jsx
@@ -1,5 +1,6 @@
 import React, { lazy } from 'react'
-import { Switch, Route, useRouteMatch } from 'react-router-dom'
+import { Switch, Route, useRouteMatch, Link } from 'react-router-dom'
+import { Result } from 'antd'
 import { UsergroupAddOutlined } from '@ant-design/icons'
 import Icon from '@ant-design/icons/lib/components/Icon'
 
@@ -55,6 +56,23 @@ const UsersPage = () => {
         exact
         path={`${path}/:uid/:activeTab?`}
         component={UpdateUserPage}
+      />
+      <Route
+        path='*'
+        render={() => (
+          <Result
+            style={{ margin: 'auto' }}
+            status={404}
+            title={
+              <>
+                <strong>404</strong>
+                <p>Page Not Found</p>
+              </>
+            }
+            subTitle="The page you are looking for doesn't exists."
+            extra={<Link to='/admin/users'>Back to Users</Link>}
+          />
+        )}
       />
     </Switch>
   )

--- a/packages/client/src/pages/WatchPage/index.jsx
+++ b/packages/client/src/pages/WatchPage/index.jsx
@@ -16,9 +16,11 @@ const WatchPage = () => {
         <Breadcrumb.Item>
           <Link to='/watches'>WATCHES</Link>
         </Breadcrumb.Item>
-        <Breadcrumb.Item>
-          <Link to={`/watches/${gender}`}>{`${gender.toUpperCase()}'S`}</Link>
-        </Breadcrumb.Item>
+        {gender && gender !== 'all' && (
+          <Breadcrumb.Item>
+            <Link to={`/watches/${gender}`}>{gender.toUpperCase()}</Link>
+          </Breadcrumb.Item>
+        )}
         <Breadcrumb.Item>
           <Link to={`/watches/${gender}?collectionName=${name}`}>
             {name.toUpperCase()}

--- a/packages/client/src/pages/WatchPage/styles.scss
+++ b/packages/client/src/pages/WatchPage/styles.scss
@@ -46,7 +46,8 @@
         object-fit: contain;
 
         &.loading {
-          display: none;
+          position: absolute;
+          visibility: hidden;
         }
       }
 

--- a/packages/client/src/pages/WatchesPage/index.jsx
+++ b/packages/client/src/pages/WatchesPage/index.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, lazy } from 'react'
 import { parse } from 'qs'
-import { useParams, useLocation, Switch, Route } from 'react-router-dom'
+import { useParams, useLocation, Switch, Route, Link } from 'react-router-dom'
+import { Result } from 'antd'
 
 import ProductsPreview from '@containers/ProductsPreview/index'
 
@@ -65,7 +66,24 @@ const WatchesPage = () => {
           />
         </div>
       </Route>
-      <Route exact path='/watches/:gender?/:name/:pid' component={WatchPage} />
+      <Route exact path='/watches/:gender/:name/:pid' component={WatchPage} />
+      <Route
+        path='*'
+        render={() => (
+          <Result
+            style={{ margin: 'auto' }}
+            status={404}
+            title={
+              <>
+                <strong>404</strong>
+                <p>Page Not Found</p>
+              </>
+            }
+            subTitle="The page you are looking for doesn't exists."
+            extra={<Link to='/'>Back to Home</Link>}
+          />
+        )}
+      />
     </Switch>
   )
 }

--- a/packages/client/src/redux/collection/collectionSlice.js
+++ b/packages/client/src/redux/collection/collectionSlice.js
@@ -1,6 +1,6 @@
 import { createSlice, createDraftSafeSelector } from '@reduxjs/toolkit'
 
-import * as collectionThunk from './collectionThunk'
+import * as collectionThunk from '@redux/collection/collectionThunk'
 
 const initialState = {
   loading: false,

--- a/packages/client/src/redux/collection/collectionThunk.js
+++ b/packages/client/src/redux/collection/collectionThunk.js
@@ -1,25 +1,30 @@
+import axios from 'axios'
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import collections from '@api/collection/index'
+import asyncThunkErrorHandler from '@utils/asyncThunkErrorHandler'
 
-// Thunks
 export const getCollections = createAsyncThunk(
   'collections/getCollections',
-  async (arg, { rejectWithValue }) => {
+  async (arg, { signal, rejectWithValue }) => {
     try {
-      const response = await collections.getCollections()
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await collections.getCollections(source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getCollectionsByGender = createAsyncThunk(
   'collections/getCollectionByGender',
-  async (arg, { rejectWithValue }) => {
+  async (arg, { signal, rejectWithValue }) => {
     let gender
 
     if (typeof arg === 'string') {
@@ -29,12 +34,19 @@ export const getCollectionsByGender = createAsyncThunk(
     }
 
     try {
-      const response = await collections.getCollectionsByGender(gender)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await collections.getCollectionsByGender(
+        gender,
+        source.token
+      )
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )

--- a/packages/client/src/redux/offer/offerSlice.js
+++ b/packages/client/src/redux/offer/offerSlice.js
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 
-import * as offerThunk from './offerThunk'
+import * as offerThunk from '@redux/offer/offerThunk'
 
 const initialState = {
   loading: false,

--- a/packages/client/src/redux/offer/offerThunk.js
+++ b/packages/client/src/redux/offer/offerThunk.js
@@ -1,18 +1,24 @@
 /* eslint-disable import/prefer-default-export */
+import axios from 'axios'
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import offers from '@api/offer/index'
+import asyncThunkErrorHandler from '@utils/asyncThunkErrorHandler'
 
 export const getOffers = createAsyncThunk(
   'offers/getOffers',
-  async (offer, { rejectWithValue }) => {
+  async (arg, { signal, rejectWithValue }) => {
     try {
-      const response = await offers.getOffers()
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await offers.getOffers(source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )

--- a/packages/client/src/redux/order/orderThunk.js
+++ b/packages/client/src/redux/order/orderThunk.js
@@ -1,32 +1,41 @@
-/* eslint-disable no-unused-vars */
+import axios from 'axios'
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import orders from '@api/order/index'
+import asyncThunkErrorHandler from '@utils/asyncThunkErrorHandler'
 
 export const getOrders = createAsyncThunk(
   'orders/getOrders',
-  async (urlQueryParams, { rejectWithValue }) => {
+  async (params, { signal, rejectWithValue }) => {
     try {
-      const response = await orders.getOrders(urlQueryParams)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await orders.getOrders(params, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getOrderById = createAsyncThunk(
   'orders/getOrderById',
-  async (oid, { rejectWithValue }) => {
+  async (oid, { signal, rejectWithValue }) => {
     try {
-      const response = await orders.getOrderById(oid)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await orders.getOrderById(oid, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )

--- a/packages/client/src/redux/product/productSlice.js
+++ b/packages/client/src/redux/product/productSlice.js
@@ -101,7 +101,7 @@ const productSlice = createSlice({
       { payload: { updatedProduct } }
     ) => {
       preview.updating = false
-      preview.data = updatedProduct
+      Object.assign(preview.data, updatedProduct)
     },
     [productThunk.updateProduct.rejected]: ({ preview }) => {
       preview.updating = false

--- a/packages/client/src/redux/product/productSlice.js
+++ b/packages/client/src/redux/product/productSlice.js
@@ -1,6 +1,6 @@
 import { createSlice, createDraftSafeSelector } from '@reduxjs/toolkit'
 
-import * as productThunk from './productThunk'
+import * as productThunk from '@redux/product/productThunk'
 
 const initialState = {
   all: {

--- a/packages/client/src/redux/product/productThunk.js
+++ b/packages/client/src/redux/product/productThunk.js
@@ -1,73 +1,99 @@
+import axios from 'axios'
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import products from '@api/product/index'
+import asyncThunkErrorHandler from '@utils/asyncThunkErrorHandler'
 
 export const getProducts = createAsyncThunk(
   'products/getProducts',
-  async (urlQueryParams, { rejectWithValue }) => {
+  async (params, { signal, rejectWithValue }) => {
     try {
-      const response = await products.getProducts(urlQueryParams)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await products.getProducts(params, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getLatestProducts = createAsyncThunk(
   'products/getLatestProducts',
-  async () => {
+  async (arg, { signal, rejectWithValue }) => {
     try {
-      const response = await products.getLatestProducts()
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await products.getLatestProducts(source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      return err.response
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getTopRatedProducts = createAsyncThunk(
   'products/getTopRatedProducts',
-  async () => {
+  async (arg, { signal, rejectWithValue }) => {
     try {
-      const response = await products.getTopRatedProducts()
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await products.getTopRatedProducts(source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      return err.response
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getProductById = createAsyncThunk(
   'products/getProductById',
-  async (pid, { rejectWithValue }) => {
+  async (pid, { signal, rejectWithValue }) => {
     try {
-      const response = await products.getProductById(pid)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await products.getProductById(pid, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
-// TODO: Add getProductReviews async thunk
-
 export const updateProduct = createAsyncThunk(
   'products/updateProduct',
-  async ({ pid, updatedData }, { rejectWithValue }) => {
+  async ({ pid, updatedData }, { signal, rejectWithValue }) => {
     try {
-      const response = await products.updateProduct(pid, updatedData)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await products.updateProduct(
+        pid,
+        updatedData,
+        source.token
+      )
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )

--- a/packages/client/src/redux/user/userSlice.js
+++ b/packages/client/src/redux/user/userSlice.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 import { createSlice, createDraftSafeSelector } from '@reduxjs/toolkit'
 
-import * as userThunk from './userThunk'
+import * as userThunk from '@redux/user/userThunk'
 
 const initialState = {
   loggedInUser: {

--- a/packages/client/src/redux/user/userThunk.js
+++ b/packages/client/src/redux/user/userThunk.js
@@ -1,177 +1,204 @@
+import axios from 'axios'
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import auth from '@api/user/auth'
 import users from '@api/user/index'
 import { getOrdersByUserId } from '@api/order/index'
+import asyncThunkErrorHandler from '@utils/asyncThunkErrorHandler'
 
 export const signin = createAsyncThunk(
   'users/signin',
-  async (userData, { rejectWithValue }) => {
+  async ({ userData }, { signal, rejectWithValue }) => {
     try {
-      const response = await auth.signin(userData)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await auth.signin(userData, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({
-        data,
-        status,
-        statusText,
-      })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const signup = createAsyncThunk(
   'users/signup',
-  async (userData, { rejectWithValue }) => {
+  async ({ userData }, { signal, rejectWithValue }) => {
     try {
-      const response = await auth.signup(userData)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await auth.signup(userData, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({
-        data,
-        status,
-        statusText,
-      })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const signout = createAsyncThunk(
   'users/signout',
-  async (user, { rejectWithValue }) => {
+  async (arg, { signal, rejectWithValue }) => {
     try {
-      const response = await auth.signout()
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await auth.signout(source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({
-        data,
-        status,
-        statusText,
-      })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const authUser = createAsyncThunk(
   'users/auth',
-  async (user, { rejectWithValue }) => {
+  async (arg, { signal, rejectWithValue }) => {
     try {
-      const response = await auth.authUser()
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await auth.authUser(source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({
-        data,
-        status,
-        statusText,
-      })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getUsers = createAsyncThunk(
   'users/getUsers',
-  async (urlQueryParams, { rejectWithValue }) => {
+  async (params, { signal, rejectWithValue }) => {
     try {
-      const response = await users.getUsers(urlQueryParams)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await users.getUsers(params, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getUserById = createAsyncThunk(
   'users/getUserById',
-  async (uid, { rejectWithValue }) => {
+  async (uid, { signal, rejectWithValue }) => {
     try {
-      const response = await users.getUserById(uid)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await users.getUserById(uid, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getPurchasedProductsAndReviews = createAsyncThunk(
   'users/getPurchasedProductsAndReviews',
-  async ({ uid, cancelToken }, { rejectWithValue }) => {
+  async ({ uid }, { signal, rejectWithValue }) => {
     try {
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
       const response = await users.getPurchasedProductsAndReviews(
         uid,
-        cancelToken.token
+        source.token
       )
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      if (!err.response) {
-        return rejectWithValue({ message: err.message, status: 'ABORTED' })
-      }
-
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const getUserOrders = createAsyncThunk(
   'users/getUserOrders',
-  async ({ uid, cancelToken }, { rejectWithValue }) => {
+  async ({ uid }, { signal, rejectWithValue }) => {
     try {
-      const response = await getOrdersByUserId(uid, cancelToken.token)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await getOrdersByUserId(uid, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const updateUser = createAsyncThunk(
   'users/updateUser',
-  async ({ uid, updatedData }, { rejectWithValue }) => {
+  async ({ uid, updatedData }, { signal, rejectWithValue }) => {
     try {
-      const response = await users.updateUser(uid, updatedData)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await users.updateUser(uid, updatedData, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const updateReview = createAsyncThunk(
   'users/updateReview',
-  async ({ rid, updatedData }, { rejectWithValue }) => {
+  async ({ rid, updatedData }, { signal, rejectWithValue }) => {
     try {
-      const response = await users.updateReview(rid, updatedData)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await users.updateReview(rid, updatedData, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const deleteReview = createAsyncThunk(
   'users/deleteReview',
-  async ({ rid }, { rejectWithValue }) => {
+  async ({ rid }, { signal, rejectWithValue }) => {
     try {
-      const response = await users.deleteReview(rid)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await users.deleteReview(rid, source.token)
       const { data, status } = response
       const {
         message,
@@ -179,22 +206,25 @@ export const deleteReview = createAsyncThunk(
       } = data
       return { reviewId, productId, status, message }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ ...data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )
 
 export const deleteUser = createAsyncThunk(
   'users/deleteUser',
-  async (uid, { rejectWithValue }) => {
+  async (uid, { signal, rejectWithValue }) => {
     try {
-      const response = await users.deleteUser(uid)
+      const source = axios.CancelToken.source()
+      signal.addEventListener('abort', () => {
+        source.cancel('Request Aborted due to component unmount.')
+      })
+
+      const response = await users.deleteUser(uid, source.token)
       const { data, status } = response
       return { ...data, status }
     } catch (err) {
-      const { data, status, statusText } = err.response
-      return rejectWithValue({ ...data, status, statusText })
+      return asyncThunkErrorHandler(err, rejectWithValue)
     }
   }
 )

--- a/packages/client/src/utils/ErrorHandler.js
+++ b/packages/client/src/utils/ErrorHandler.js
@@ -1,0 +1,15 @@
+export default class ErrorHandler extends Error {
+  constructor(
+    message = 'Something went wrong, please try again later.',
+    statusCode = 500,
+    statusText = 'Server Error',
+    options = undefined
+  ) {
+    super(message, { cause: options?.cause })
+    this.status = statusCode
+    this.statusText = statusText
+    this.redirect = {
+      ...(options?.redirect ?? { to: '/', text: 'Back to Home' }),
+    }
+  }
+}

--- a/packages/client/src/utils/asyncThunkErrorHandler.js
+++ b/packages/client/src/utils/asyncThunkErrorHandler.js
@@ -1,0 +1,56 @@
+import ErrorHandler from '@utils/ErrorHandler'
+
+export default (err, rejectWithValue) => {
+  if (err.response) {
+    /* The request was made and the server responded with a status code
+         that falls out of the range of 2xx */
+    const { data, status, statusText } = err.response
+    return rejectWithValue({ data, status, statusText })
+  }
+
+  if (err.request) {
+    /* The request was made but no response was received
+         `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+         http.ClientRequest in node.js */
+    const { code, isAxiosError, message, stack } = err
+    return rejectWithValue({ code, isAxiosError, message, stack })
+  }
+
+  // Something happened in setting up the request that triggered an Error
+  return rejectWithValue({
+    status: 500,
+    statusText: 'Server Error',
+    data: { message: 'Something went wrong, please try again later.' },
+  })
+}
+
+export const handleAsyncThunkError = (
+  thunkError,
+  showBoundary,
+  options = { redirect: undefined, showBoundaryOnlyOnServerError: undefined }
+) => {
+  if (thunkError.name !== 'AbortError') {
+    const {
+      status,
+      statusText,
+      data: { error, message } = {
+        error: undefined,
+        message: undefined,
+      },
+    } = thunkError
+
+    const boundaryError = new ErrorHandler(message, status, statusText, {
+      ...(error && { cause: error }),
+      redirect: options.redirect,
+    })
+
+    if (options.showBoundaryOnlyOnServerError) {
+      if (status === 500) {
+        showBoundary(boundaryError)
+      }
+      return
+    }
+
+    showBoundary(boundaryError)
+  }
+}

--- a/packages/client/src/validation/product-validation.js
+++ b/packages/client/src/validation/product-validation.js
@@ -7,10 +7,15 @@ const nameValidation = Yup.string()
   .max(30, 'Maximum 30 characters long.')
   .required('Name is required field.')
 
-const modelValidation = Yup.string()
-  .trim()
-  .min(2, 'Must be at least 2 characters long.')
-  .required('Model is required field.')
+const modelValidation = (existingModels = [], errMsg = '') =>
+  Yup.string()
+    .trim()
+    .min(2, 'Must be at least 2 characters long.')
+    .required('Model is required field.')
+    .notOneOf(
+      existingModels,
+      errMsg || 'Product with provided model already exists.'
+    )
 
 const collectionNameValidation = Yup.string()
   .trim()
@@ -76,18 +81,19 @@ const specificationValidation = Yup.string()
   .trim()
   .required('Specifications is required field.')
 
-export const productValidationSchema = Yup.object().shape({
-  name: nameValidation,
-  model: modelValidation,
-  collectionName: collectionNameValidation,
-  color: colorValidation,
-  price: priceValidation,
-  discount: discountValidation,
-  inStock: inStockValidation,
-  desc: descriptionValidation,
-  images: imagesValidation,
-  materials: materialsValidation,
-  types: typesValidation,
-  mainFeatures: mainFeaturesValidation,
-  specifications: specificationValidation,
-})
+export const productValidationSchema = (existingModels, errMsg) =>
+  Yup.object().shape({
+    name: nameValidation,
+    model: modelValidation(existingModels, errMsg),
+    collectionName: collectionNameValidation,
+    color: colorValidation,
+    price: priceValidation,
+    discount: discountValidation,
+    inStock: inStockValidation,
+    desc: descriptionValidation,
+    images: imagesValidation,
+    materials: materialsValidation,
+    types: typesValidation,
+    mainFeatures: mainFeaturesValidation,
+    specifications: specificationValidation,
+  })

--- a/packages/server/config/default.js
+++ b/packages/server/config/default.js
@@ -2,6 +2,9 @@
 if (process.env.NODE_ENV !== 'production') require('dotenv').config()
 
 module.exports = {
+  CLIENT: {
+    BASE_URL: 'http://localhost:3000',
+  },
   SERVER: {
     PORT: 5000,
     HOST: 'localhost',

--- a/packages/server/config/local-development.js
+++ b/packages/server/config/local-development.js
@@ -1,4 +1,7 @@
 module.exports = {
+  CLIENT: {
+    BASE_URL: process.env.CLIENT_BASE_URL_DEV,
+  },
   SERVER: {
     HOST: process.env.HOST_DEV,
   },

--- a/packages/server/config/local-stage.js
+++ b/packages/server/config/local-stage.js
@@ -1,4 +1,7 @@
 module.exports = {
+  CLIENT: {
+    BASE_URL: process.env.CLIENT_BASE_URL_LOCAL,
+  },
   SERVER: {
     HOST: process.env.HOST_LOCAL,
   },

--- a/packages/server/controllers/products-controller.js
+++ b/packages/server/controllers/products-controller.js
@@ -608,7 +608,7 @@ const updateProduct = async (req, res, next) => {
       'images[]': newUploadedImages,
     },
     body: {
-      previewImg: [existingPreviewImg] = '',
+      previewImg: existingPreviewImg = '',
       images: existingImages = [],
       collectionName,
       specifications,
@@ -674,6 +674,7 @@ const updateProduct = async (req, res, next) => {
           console.log({ error })
         }
       })
+
       updatedImagesPaths = updatedImagesPaths.filter(
         imgPath => !removedFileList.includes(imgPath)
       )

--- a/packages/server/routes/users-routes.js
+++ b/packages/server/routes/users-routes.js
@@ -1,6 +1,7 @@
 const router = require('express').Router()
 const passport = require('passport')
 const multer = require('multer')
+const config = require('config')
 
 const upload = multer()
 
@@ -35,7 +36,7 @@ router.get('/', authJwt, isAdmin, getUsers)
 /** @method GET @access PRIVATE @desc Get total user documents count */
 router.get('/count', authJwt, isAdmin, getTotalUsersCount)
 
-/** @method GET @access PUBLIC @desc Get an currently authenticated user. */
+/** @method GET @access PUBLIC @desc Get the currently authenticated user. */
 router.get('/auth', authJwt, (req, res) => {
   if (req.isAuthenticated()) {
     return res.status(200).json({ loggedInUser: req.user })
@@ -92,14 +93,16 @@ router.get('/auth/google/callback', auth('google'), (req, res) => {
     const { state } = req.query
     const { redirectTo } = JSON.parse(Buffer.from(state, 'base64').toString())
     if (typeof redirectTo === 'string' && redirectTo.startsWith('/')) {
-      res.redirect(`http://localhost:3000${redirectTo}`)
+      res.redirect(`${config.get('CLIENT.BASE_URL') + redirectTo}`)
     }
   } catch {
     if (req.user.isAdmin) {
-      return res.redirect('http://localhost:3000/admin/dashboard')
+      return res.redirect(`${config.get('CLIENT.BASE_URL')}/admin/dashboard`)
     }
 
-    return res.redirect(`http://localhost:3000/users/${req.user.id}/profile`)
+    return res.redirect(
+      `${config.get('CLIENT.BASE_URL')}/users/${req.user.id}/profile`
+    )
   }
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13201,6 +13201,13 @@ react-easy-crop@^3.3.1:
     normalize-wheel "^1.0.1"
     tslib "2.0.1"
 
+react-error-boundary@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
+  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"


### PR DESCRIPTION
- Refactor the **Axios API requests configurations** for all API endpoints to use the **Axios CancelToken API**,
- Refactor the **asyncThunk payload creators** to use the **thunkAPI AbortController's signal** and add an abort event listener that'll cancel a costly running **Axios request via CancelToken API**,
- Set up the **ErrorBoundary** for the main **App and Auth/Dashboard/Main Layout wrapper Components** to show the nearest **ErrorBoundary** with the **FallbackComponent UI** that'll catch any errors:
    - thrown at runtime or within the Component lifecycle methods,
    - that occured inside or after the async code has run and
    - thrown in event listeners/handlers.